### PR TITLE
Linux fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 cmake_minimum_required(VERSION 2.8)
+include(CTest)
 add_subdirectory(mediafire_sdk)

--- a/src/mediafire_sdk/CMakeLists.txt
+++ b/src/mediafire_sdk/CMakeLists.txt
@@ -73,6 +73,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
             endforeach(flag_var)
         endif( USE_MSVC_STATIC_RUNTIME )
     endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  cmake_minimum_required (VERSION 2.6)
+  find_package (Threads)
+  SET(PTHREAD_LIBRARY ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 # Boost asio SSL depends on OpenSSL

--- a/src/mediafire_sdk/utils/string.cpp
+++ b/src/mediafire_sdk/utils/string.cpp
@@ -11,9 +11,9 @@
 #       include <windows.h>
 #       include <vector>
 #else
-#       include <codecvt>
 #       include <locale>
 #       include <string>
+#       include "boost/locale/encoding_utf.hpp"
 #endif
 
 #if defined(__MINGW32__)
@@ -125,6 +125,9 @@ std::wstring mf::utils::bytes_to_wide(const std::string & byte_string)
     return buffer;
 }
 #else
+
+using boost::locale::conv::utf_to_utf;
+
 uint64_t mf::utils::str_to_uint64(
         const std::string & str,
         int base
@@ -134,14 +137,12 @@ uint64_t mf::utils::str_to_uint64(
 }
 std::string mf::utils::wide_to_bytes(const std::wstring & str)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.to_bytes(str);
+    return utf_to_utf<char>(str.c_str(), str.c_str() + str.size());
 }
 
 std::wstring mf::utils::bytes_to_wide(const std::string & str)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.from_bytes(str);
+    return utf_to_utf<wchar_t>(str.c_str(), str.c_str() + str.size());
 }
 #endif
 


### PR DESCRIPTION
- Enable pthread linking on Linux
- Use boost locale instead of codecvt which is not available yet in gcc 4.8.1
- Enable CTest for repository so running ```ctest``` in build directory processes unit tests
