### PR TITLE
Encapsulate API fields only available on success to prevent undefined behavior

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,66 @@
+---
+Language:        Cpp
+# public:/private:/protected: indent modifier
+AccessModifierOffset: -4
+
+# Align parameters to open bracket column
+AlignAfterOpenBracket: true
+
+# Place newline escape on left if false, right if true
+AlignEscapedNewlinesLeft: false
+
+# Place function definition arguments one per line if they don't fit, and indent
+# them extra
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BinPackArguments: true
+BinPackParameters: false
+ConstructorInitializerIndentWidth: 8
+
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: true
+BreakBeforeBinaryOperators: true
+BreakBeforeTernaryOperators: true
+
+# Set to true to place , at beginning of lines
+# BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     80
+# DerivePointerAlignment: true
+# ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+IndentWrappedFunctionNames: false
+# IndentFunctionDeclarationAfterType: false
+# MaxEmptyLinesToKeep: 1
+# KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: None
+# ObjCSpaceAfterProperty: false
+# ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: true
+Standard:        Cpp11
+IndentWidth:     4
+UseTab:          Never
+BreakBeforeBraces: Allman
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 8
+CommentPragmas:  '^ IWYU pragma:'
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+SpaceBeforeParens: ControlStatements
+DisableFormat:   false

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 cmake_minimum_required(VERSION 2.8)
+include(CTest)
 add_subdirectory(mediafire_sdk)

--- a/src/mediafire_sdk/CMakeLists.txt
+++ b/src/mediafire_sdk/CMakeLists.txt
@@ -73,6 +73,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
             endforeach(flag_var)
         endif( USE_MSVC_STATIC_RUNTIME )
     endif()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  cmake_minimum_required (VERSION 2.6)
+  find_package (Threads)
+  SET(PTHREAD_LIBRARY ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 # Boost asio SSL depends on OpenSSL

--- a/src/mediafire_sdk/api/actions/get_changes_device.hpp
+++ b/src/mediafire_sdk/api/actions/get_changes_device.hpp
@@ -27,8 +27,11 @@ public:
     using DeviceGetChangesResponseType =
             typename DeviceGetChangesRequestType::ResponseType;
 
-    using File = typename DeviceGetChangesResponseType::File;
-    using Folder = typename DeviceGetChangesResponseType::Folder;
+    using DeviceGetChangesResponseDataType =
+            typename DeviceGetChangesRequestType::ResponseDataType;
+
+    using File = typename DeviceGetChangesResponseDataType::File;
+    using Folder = typename DeviceGetChangesResponseDataType::Folder;
 
     // The struct for the errors we might return
     struct DeviceGetStatusErrorType

--- a/src/mediafire_sdk/api/actions/get_folder_contents.hpp
+++ b/src/mediafire_sdk/api/actions/get_folder_contents.hpp
@@ -29,11 +29,12 @@ public:
     // Some convenience typedefs
     using RequestType = TRequest;
     using ResponseType = typename RequestType::ResponseType;
+    using ResponseDataType = typename RequestType::ResponseDataType;
 
     using ContentType = typename RequestType::ContentType;
 
-    using File = typename ResponseType::File;
-    using Folder = typename ResponseType::Folder;
+    using File = typename ResponseDataType::File;
+    using Folder = typename ResponseDataType::Folder;
 
     // The struct for the errors we might return
     struct ErrorType
@@ -52,8 +53,8 @@ public:
     };
 
     using CallbackType = std::function<void(
-            const std::vector<typename ResponseType::File> & files,
-            const std::vector<typename ResponseType::Folder> & folders,
+            const std::vector<typename ResponseDataType::File> & files,
+            const std::vector<typename ResponseDataType::Folder> & folders,
             const std::vector<ErrorType> & errors)>;
 
 public:
@@ -80,8 +81,10 @@ private:
                       const FilesOrFoldersOrBoth & files_or_folders_or_both,
                       CallbackType && callback);
 
-    void HandleFolderGetContentsFiles(const ResponseType & response);
-    void HandleFolderGetContentsFolders(const ResponseType & response);
+    void HandleFolderGetContentsFiles(const ResponseType & response,
+                                      uint32_t chunk_number);
+    void HandleFolderGetContentsFolders(const ResponseType & response,
+                                        uint32_t chunk_number);
 
     void CoroutineBody(pull_type & yield) override;
 

--- a/src/mediafire_sdk/api/actions/get_foreign_changes_device.hpp
+++ b/src/mediafire_sdk/api/actions/get_foreign_changes_device.hpp
@@ -22,9 +22,11 @@ public:
     using DeviceGetForeignChangesRequestType = TDeviceGetForeignChangesRequest;
     using DeviceGetForeignChangesResponseType =
             typename DeviceGetForeignChangesRequestType::ResponseType;
+    using DeviceGetForeignChangesResponseDataType =
+            typename DeviceGetForeignChangesRequestType::ResponseDataType;
 
-    using File = typename DeviceGetForeignChangesResponseType::File;
-    using Folder = typename DeviceGetForeignChangesResponseType::Folder;
+    using File = typename DeviceGetForeignChangesResponseDataType::File;
+    using Folder = typename DeviceGetForeignChangesResponseDataType::Folder;
 
     // The struct for the errors we might returnu
     struct DeviceGetForeignChangesErrorType

--- a/src/mediafire_sdk/api/actions/get_foreign_resources_device.hpp
+++ b/src/mediafire_sdk/api/actions/get_foreign_resources_device.hpp
@@ -22,9 +22,11 @@ public:
             = TDeviceGetForeignResourcesRequest;
     using DeviceGetForeignResourcesResponseType =
             typename DeviceGetForeignResourcesRequestType::ResponseType;
+    using DeviceGetForeignResourcesResponseDataType =
+            typename DeviceGetForeignResourcesRequestType::ResponseDataType;
 
-    using File = typename DeviceGetForeignResourcesResponseType::File;
-    using Folder = typename DeviceGetForeignResourcesResponseType::Folder;
+    using File = typename DeviceGetForeignResourcesResponseDataType::File;
+    using Folder = typename DeviceGetForeignResourcesResponseDataType::Folder;
 
     // The struct for the errors we might return
     struct ErrorType

--- a/src/mediafire_sdk/api/actions/get_foreign_resources_device_impl.hpp
+++ b/src/mediafire_sdk/api/actions/get_foreign_resources_device_impl.hpp
@@ -53,15 +53,17 @@ void GetForeignResourcesDevice<TDeviceGetForeignResourcesRequest>::
     auto HandleDeviceGetForeignResources =
             [this, self](const DeviceGetForeignResourcesResponseType & response)
     {
-        if (response.error_code)
+        if (!response.response_data)
         {
             errors_.push_back(
                     ErrorType(response.error_code, response.error_string));
         }
         else
         {
-            files_ = response.files;
-            folders_ = response.folders;
+            const auto & data = *response.response_data;
+
+            files_ = data.files;
+            folders_ = data.folders;
         }
 
         request_ = nullptr;  // Must free request_ or coroutine cannot be

--- a/src/mediafire_sdk/api/billing/cancel_plan/v1_1.cpp
+++ b/src/mediafire_sdk/api/billing/cancel_plan/v1_1.cpp
@@ -96,11 +96,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.cancel_date",
-            &response->cancel_date ) )
+            &response_data_ptr->cancel_date ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.cancel_date\"");
@@ -109,7 +114,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.confirmation",
-            &response->confirmation ) )
+            &response_data_ptr->confirmation ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.confirmation\"");
@@ -122,9 +127,12 @@ void Impl::ParseResponse( Response * response )
                 "response.last_invoice",
                 &optarg) )
         {
-            response->last_invoice = optarg;
+            response_data_ptr->last_invoice = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/billing/cancel_plan/v1_1.hpp
+++ b/src/mediafire_sdk/api/billing/cancel_plan/v1_1.hpp
@@ -35,10 +35,12 @@ enum class CancellationReason
 };
 
 /**
- * @class Response
- * @brief Response from API request "billing/cancel_plan"
+ * @class ResponseData
+ * @brief Response data from API request "billing/cancel_plan"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.cancel_date" */
@@ -49,6 +51,17 @@ public:
 
     /** API response field "response.last_invoice" */
     boost::optional<std::string> last_invoice;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "billing/cancel_plan"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -152,7 +165,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/billing/change_plan/v1_1.cpp
+++ b/src/mediafire_sdk/api/billing/change_plan/v1_1.cpp
@@ -97,6 +97,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         std::string optarg;
@@ -105,7 +110,7 @@ void Impl::ParseResponse( Response * response )
                 "response.nextbilling",
                 &optarg) )
         {
-            response->next_billing = optarg;
+            response_data_ptr->next_billing = optarg;
         }
     }
 
@@ -118,9 +123,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->info_only = InfoOnly::No;
+                response_data_ptr->info_only = InfoOnly::No;
             else if ( optval == "yes" )
-                response->info_only = InfoOnly::Yes;
+                response_data_ptr->info_only = InfoOnly::Yes;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -136,7 +141,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.newpid",
-            &response->new_pid ) )
+            &response_data_ptr->new_pid ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.newpid\"");
@@ -145,7 +150,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.amount",
-            &response->amount ) )
+            &response_data_ptr->amount ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.amount\"");
@@ -154,10 +159,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.interval",
-            &response->interval ) )
+            &response_data_ptr->interval ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.interval\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/billing/change_plan/v1_1.hpp
+++ b/src/mediafire_sdk/api/billing/change_plan/v1_1.hpp
@@ -35,10 +35,12 @@ enum class InfoOnly
 };
 
 /**
- * @class Response
- * @brief Response from API request "billing/change_plan"
+ * @class ResponseData
+ * @brief Response data from API request "billing/change_plan"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.nextbilling" */
@@ -55,6 +57,17 @@ public:
 
     /** API response field "response.interval" */
     uint32_t interval;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "billing/change_plan"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -98,7 +111,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/billing/get_invoice/v1_1.cpp
+++ b/src/mediafire_sdk/api/billing/get_invoice/v1_1.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v1_1;  // NOLINT
 bool ProductFromPropertyBranch(
         Response * response,
-        Response::Product * value,
+        ResponseData::Product * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -311,15 +311,20 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->recurring_startdate = boost::posix_time::not_a_date_time;
-    response->recurring_enddate = boost::posix_time::not_a_date_time;
-    response->next_bandwidth = boost::posix_time::not_a_date_time;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->recurring_startdate = boost::posix_time::not_a_date_time;
+    response_data_ptr->recurring_enddate = boost::posix_time::not_a_date_time;
+    response_data_ptr->next_bandwidth = boost::posix_time::not_a_date_time;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.invoice_id",
-            &response->invoice_id ) )
+            &response_data_ptr->invoice_id ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.invoice_id\"");
@@ -328,7 +333,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.invoice_num",
-            &response->invoice_num ) )
+            &response_data_ptr->invoice_num ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.invoice_num\"");
@@ -337,7 +342,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.payment_method",
-            &response->payment_method ) )
+            &response_data_ptr->payment_method ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.payment_method\"");
@@ -346,7 +351,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.recurring_status",
-            &response->recurring_status ) )
+            &response_data_ptr->recurring_status ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.recurring_status\"");
@@ -355,7 +360,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.recurring_profile_id",
-            &response->recurring_profile_id ) )
+            &response_data_ptr->recurring_profile_id ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.recurring_profile_id\"");
@@ -364,7 +369,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.date_created",
-            &response->created_datetime ) )
+            &response_data_ptr->created_datetime ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.date_created\"");
@@ -377,7 +382,7 @@ void Impl::ParseResponse( Response * response )
                 "response.invoice.company_id",
                 &optarg) )
         {
-            response->company_id = optarg;
+            response_data_ptr->company_id = optarg;
         }
     }
 
@@ -385,7 +390,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.product_id",
-            &response->product_id ) )
+            &response_data_ptr->product_id ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.product_id\"");
@@ -394,7 +399,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.product_description",
-            &response->product_description ) )
+            &response_data_ptr->product_description ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.product_description\"");
@@ -403,7 +408,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.country",
-            &response->country ) )
+            &response_data_ptr->country ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.country\"");
@@ -412,7 +417,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.initial_amount",
-            &response->initial_amount ) )
+            &response_data_ptr->initial_amount ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.initial_amount\"");
@@ -421,7 +426,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.initial_tax",
-            &response->initial_tax ) )
+            &response_data_ptr->initial_tax ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.initial_tax\"");
@@ -430,7 +435,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.initial_total",
-            &response->initial_total ) )
+            &response_data_ptr->initial_total ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.initial_total\"");
@@ -439,7 +444,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.recurring_amount",
-            &response->recurring_amount ) )
+            &response_data_ptr->recurring_amount ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.recurring_amount\"");
@@ -448,7 +453,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.recurring_tax",
-            &response->recurring_tax ) )
+            &response_data_ptr->recurring_tax ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.recurring_tax\"");
@@ -457,7 +462,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.recurring_total",
-            &response->recurring_total ) )
+            &response_data_ptr->recurring_total ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.recurring_total\"");
@@ -466,19 +471,19 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.invoice.recurring_startdate",
-            &response->recurring_startdate);
+            &response_data_ptr->recurring_startdate);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.invoice.recurring_enddate",
-            &response->recurring_enddate);
+            &response_data_ptr->recurring_enddate);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.invoice.next_bandwidth",
-            &response->next_bandwidth);
+            &response_data_ptr->next_bandwidth);
 
     // create_content_parse_single optional no default
     {
@@ -488,7 +493,7 @@ void Impl::ParseResponse( Response * response )
                 "response.invoice.previous_invoice",
                 &optarg) )
         {
-            response->previous_invoice_id = optarg;
+            response_data_ptr->previous_invoice_id = optarg;
         }
     }
 
@@ -496,7 +501,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.invoice.promo_code",
-            &response->promo_code ) )
+            &response_data_ptr->promo_code ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.promo_code\"");
@@ -506,11 +511,11 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.invoice.product");
 
-        Response::Product optarg;
+        ResponseData::Product optarg;
         if ( ProductFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->product = std::move(optarg);
+            response_data_ptr->product = std::move(optarg);
         }
         else
         {
@@ -529,6 +534,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice.product\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/billing/get_invoice/v1_1.hpp
+++ b/src/mediafire_sdk/api/billing/get_invoice/v1_1.hpp
@@ -83,13 +83,15 @@ enum class Yearly
 };
 
 /**
- * @class Response
- * @brief Response from API request "billing/get_invoice"
+ * @class ResponseData
+ * @brief Response data from API request "billing/get_invoice"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         recurring_startdate(boost::posix_time::not_a_date_time),
         recurring_enddate(boost::posix_time::not_a_date_time),
         next_bandwidth(boost::posix_time::not_a_date_time)
@@ -223,6 +225,17 @@ public:
     Product product;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "billing/get_invoice"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -250,7 +263,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/billing/get_plans/v1_1.hpp
+++ b/src/mediafire_sdk/api/billing/get_plans/v1_1.hpp
@@ -35,10 +35,12 @@ enum class Recurring
 };
 
 /**
- * @class Response
- * @brief Response from API request "billing/get_plans"
+ * @class ResponseData
+ * @brief Response data from API request "billing/get_plans"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Plan
@@ -83,6 +85,17 @@ public:
     std::vector<Plan> plans;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "billing/get_plans"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -118,7 +131,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/billing/get_products/v1_1.cpp
+++ b/src/mediafire_sdk/api/billing/get_products/v1_1.cpp
@@ -54,7 +54,7 @@ namespace {
 using namespace v1_1;  // NOLINT
 bool ProductFromPropertyBranch(
         Response * response,
-        Response::Product * value,
+        ResponseData::Product * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -353,18 +353,23 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.products");
-        response->products.reserve( response->pt.size() );
+        response_data_ptr->products.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Product optarg;
+            ResponseData::Product optarg;
             if ( ProductFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->products.push_back(std::move(optarg));
+                response_data_ptr->products.push_back(std::move(optarg));
             else
                 return;  // error set already
         }
@@ -377,6 +382,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.products\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/billing/get_products/v1_1.hpp
+++ b/src/mediafire_sdk/api/billing/get_products/v1_1.hpp
@@ -75,10 +75,12 @@ enum class Legacy
 };
 
 /**
- * @class Response
- * @brief Response from API request "billing/get_products"
+ * @class ResponseData
+ * @brief Response data from API request "billing/get_products"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Product
@@ -148,6 +150,17 @@ public:
     };
     /** API response field "response.products" */
     std::vector<Product> products;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "billing/get_products"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -225,7 +238,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/billing/purchase_plan/v1_1.cpp
+++ b/src/mediafire_sdk/api/billing/purchase_plan/v1_1.cpp
@@ -111,14 +111,19 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->created_datetime = boost::posix_time::not_a_date_time;
-    response->previous_invoice_datetime = boost::posix_time::not_a_date_time;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->created_datetime = boost::posix_time::not_a_date_time;
+    response_data_ptr->previous_invoice_datetime = boost::posix_time::not_a_date_time;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.invoice",
-            &response->invoice ) )
+            &response_data_ptr->invoice ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.invoice\"");
@@ -127,13 +132,13 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "created",
-            &response->created_datetime);
+            &response_data_ptr->created_datetime);
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.total",
-            &response->total ) )
+            &response_data_ptr->total ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.total\"");
@@ -142,7 +147,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.product",
-            &response->product_id ) )
+            &response_data_ptr->product_id ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.product\"");
@@ -151,7 +156,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.premium",
-            &response->premium ) )
+            &response_data_ptr->premium ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.premium\"");
@@ -160,7 +165,10 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "lastpremium",
-            &response->previous_invoice_datetime);
+            &response_data_ptr->previous_invoice_datetime);
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/billing/purchase_plan/v1_1.hpp
+++ b/src/mediafire_sdk/api/billing/purchase_plan/v1_1.hpp
@@ -43,13 +43,15 @@ enum class KeepCard
 };
 
 /**
- * @class Response
- * @brief Response from API request "billing/purchase_plan"
+ * @class ResponseData
+ * @brief Response data from API request "billing/purchase_plan"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         created_datetime(boost::posix_time::not_a_date_time),
         previous_invoice_datetime(boost::posix_time::not_a_date_time)
     {}
@@ -70,6 +72,17 @@ public:
 
     /** API response field "lastpremium" */
     boost::posix_time::ptime previous_invoice_datetime;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "billing/purchase_plan"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -227,7 +240,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/contact/add/v1_1.cpp
+++ b/src/mediafire_sdk/api/contact/add/v1_1.cpp
@@ -114,6 +114,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/contact/add/v1_1.hpp
+++ b/src/mediafire_sdk/api/contact/add/v1_1.hpp
@@ -49,12 +49,25 @@ enum class Gender
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "contact/add"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "contact/add"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -177,7 +190,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/contact/fetch/v0.cpp
+++ b/src/mediafire_sdk/api/contact/fetch/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool ContactFromPropertyBranch(
         Response * response,
-        Response::Contact * value,
+        ResponseData::Contact * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -109,24 +109,32 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.contacts");
-        response->contacts.reserve( response->pt.size() );
+        response_data_ptr->contacts.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Contact optarg;
+            ResponseData::Contact optarg;
             if ( ContactFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->contacts.push_back(std::move(optarg));
+                response_data_ptr->contacts.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/contact/fetch/v0.hpp
+++ b/src/mediafire_sdk/api/contact/fetch/v0.hpp
@@ -27,10 +27,12 @@ namespace fetch {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "contact/fetch"
+ * @class ResponseData
+ * @brief Response data from API request "contact/fetch"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Contact
@@ -40,6 +42,17 @@ public:
     };
     /** API response field "response.contacts" */
     std::vector<Contact> contacts;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "contact/fetch"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -59,7 +72,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_changes/v0.cpp
+++ b/src/mediafire_sdk/api/device/get_changes/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool FileFromPropertyBranch(
         Response * response,
-        Response::File * value,
+        ResponseData::File * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -87,7 +87,7 @@ bool FileFromPropertyBranch(
 using namespace v0;  // NOLINT
 bool FolderFromPropertyBranch(
         Response * response,
-        Response::Folder * value,
+        ResponseData::Folder * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -203,11 +203,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
@@ -216,7 +221,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.changes_list_block",
-            &response->changes_list_block ) )
+            &response_data_ptr->changes_list_block ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.changes_list_block\"");
@@ -225,14 +230,14 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.updated.files");
-        response->updated_files.reserve( response->pt.size() );
+        response_data_ptr->updated_files.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::File optarg;
+            ResponseData::File optarg;
             if ( FileFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->updated_files.push_back(std::move(optarg));
+                response_data_ptr->updated_files.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -244,14 +249,14 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.deleted.files");
-        response->deleted_files.reserve( response->pt.size() );
+        response_data_ptr->deleted_files.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::File optarg;
+            ResponseData::File optarg;
             if ( FileFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->deleted_files.push_back(std::move(optarg));
+                response_data_ptr->deleted_files.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -263,14 +268,14 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.updated.folders");
-        response->updated_folders.reserve( response->pt.size() );
+        response_data_ptr->updated_folders.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Folder optarg;
+            ResponseData::Folder optarg;
             if ( FolderFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->updated_folders.push_back(std::move(optarg));
+                response_data_ptr->updated_folders.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -282,20 +287,23 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.deleted.folders");
-        response->deleted_folders.reserve( response->pt.size() );
+        response_data_ptr->deleted_folders.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Folder optarg;
+            ResponseData::Folder optarg;
             if ( FolderFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->deleted_folders.push_back(std::move(optarg));
+                response_data_ptr->deleted_folders.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/get_changes/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_changes/v0.hpp
@@ -27,10 +27,12 @@ namespace get_changes {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "device/get_changes"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_changes"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct File
@@ -80,6 +82,17 @@ public:
     std::vector<Folder> deleted_folders;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "device/get_changes"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -101,7 +114,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_foreign_changes/v1_3.hpp
+++ b/src/mediafire_sdk/api/device/get_foreign_changes/v1_3.hpp
@@ -27,10 +27,12 @@ namespace get_foreign_changes {
 namespace v1_3 {
 
 /**
- * @class Response
- * @brief Response from API request "device/get_foreign_changes"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_foreign_changes"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct File
@@ -80,6 +82,17 @@ public:
     std::vector<Folder> deleted_folders;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "device/get_foreign_changes"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -103,7 +116,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_foreign_resources/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_foreign_resources/v0.hpp
@@ -51,10 +51,12 @@ enum class SyncToDesktopFilter
 };
 
 /**
- * @class Response
- * @brief Response from API request "device/get_foreign_resources"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_foreign_resources"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct File
@@ -149,6 +151,17 @@ public:
     std::vector<Folder> folders;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "device/get_foreign_resources"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -213,7 +226,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_patch/v0.cpp
+++ b/src/mediafire_sdk/api/device/get_patch/v0.cpp
@@ -88,11 +88,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.patch_link",
-            &response->patch_link ) )
+            &response_data_ptr->patch_link ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.patch_link\"");
@@ -101,10 +106,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.patch_hash",
-            &response->patch_hash ) )
+            &response_data_ptr->patch_hash ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.patch_hash\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/get_patch/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_patch/v0.hpp
@@ -27,10 +27,12 @@ namespace get_patch {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "device/get_patch"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_patch"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.patch_link" */
@@ -38,6 +40,17 @@ public:
 
     /** API response field "response.patch_hash" */
     std::string patch_hash;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "device/get_patch"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -65,7 +78,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_resource_shares/v0.cpp
+++ b/src/mediafire_sdk/api/device/get_resource_shares/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool ShareFromPropertyBranch(
         Response * response,
-        Response::Share * value,
+        ResponseData::Share * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -187,24 +187,32 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.shares");
-        response->shares.reserve( response->pt.size() );
+        response_data_ptr->shares.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Share optarg;
+            ResponseData::Share optarg;
             if ( ShareFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->shares.push_back(std::move(optarg));
+                response_data_ptr->shares.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/get_resource_shares/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_resource_shares/v0.hpp
@@ -37,10 +37,12 @@ enum class Permissions
 };
 
 /**
- * @class Response
- * @brief Response from API request "device/get_resource_shares"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_resource_shares"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Share
@@ -65,6 +67,17 @@ public:
     };
     /** API response field "response.shares" */
     std::vector<Share> shares;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "device/get_resource_shares"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -96,7 +109,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_status/v0.cpp
+++ b/src/mediafire_sdk/api/device/get_status/v0.cpp
@@ -75,6 +75,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     {
         std::string optval;
         // create_content_enum_parse TSingle
@@ -84,9 +89,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->async_jobs_in_progress = AsyncJobs::Stopped;
+                response_data_ptr->async_jobs_in_progress = AsyncJobs::Stopped;
             else if ( optval == "yes" )
-                response->async_jobs_in_progress = AsyncJobs::Running;
+                response_data_ptr->async_jobs_in_progress = AsyncJobs::Running;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -102,10 +107,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/get_status/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_status/v0.hpp
@@ -35,10 +35,12 @@ enum class AsyncJobs
 };
 
 /**
- * @class Response
- * @brief Response from API request "device/get_status"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_status"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.async_jobs_in_progress" */
@@ -46,6 +48,17 @@ public:
 
     /** API response field "response.device_revision" */
     uint32_t device_revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "device/get_status"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -76,7 +89,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_updates/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_updates/v0.hpp
@@ -27,10 +27,12 @@ namespace get_updates {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "device/get_updates"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_updates"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Update
@@ -55,6 +57,17 @@ public:
 
     /** API response field "response.updates" */
     std::vector<Update> updates;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "device/get_updates"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -87,7 +100,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/get_user_shares/v0.cpp
+++ b/src/mediafire_sdk/api/device/get_user_shares/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool ShareFromPropertyBranch(
         Response * response,
-        Response::Share * value,
+        ResponseData::Share * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -207,24 +207,32 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.shares");
-        response->shares.reserve( response->pt.size() );
+        response_data_ptr->shares.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Share optarg;
+            ResponseData::Share optarg;
             if ( ShareFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->shares.push_back(std::move(optarg));
+                response_data_ptr->shares.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/get_user_shares/v0.hpp
+++ b/src/mediafire_sdk/api/device/get_user_shares/v0.hpp
@@ -45,10 +45,12 @@ enum class Permissions
 };
 
 /**
- * @class Response
- * @brief Response from API request "device/get_user_shares"
+ * @class ResponseData
+ * @brief Response data from API request "device/get_user_shares"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Share
@@ -79,6 +81,17 @@ public:
     };
     /** API response field "response.shares" */
     std::vector<Share> shares;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "device/get_user_shares"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -117,7 +130,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/share_resources/v0.cpp
+++ b/src/mediafire_sdk/api/device/share_resources/v0.cpp
@@ -102,14 +102,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/share_resources/v0.hpp
+++ b/src/mediafire_sdk/api/device/share_resources/v0.hpp
@@ -37,14 +37,27 @@ enum class Permissions
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "device/share_resources"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    uint32_t device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "device/share_resources"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    uint32_t device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -110,7 +123,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/device/unshare_resource/v0.cpp
+++ b/src/mediafire_sdk/api/device/unshare_resource/v0.cpp
@@ -81,14 +81,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/device/unshare_resource/v0.hpp
+++ b/src/mediafire_sdk/api/device/unshare_resource/v0.hpp
@@ -27,14 +27,27 @@ namespace unshare_resource {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "device/unshare_resource"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    uint32_t device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "device/unshare_resource"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    uint32_t device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -65,7 +78,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/configure_one_time_key/v1_1.cpp
+++ b/src/mediafire_sdk/api/file/configure_one_time_key/v1_1.cpp
@@ -104,13 +104,21 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->one_time_key_request_count = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->one_time_key_request_count = 0;
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_key_request_count",
-            &response->one_time_key_request_count);
+            &response_data_ptr->one_time_key_request_count);
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/configure_one_time_key/v1_1.hpp
+++ b/src/mediafire_sdk/api/file/configure_one_time_key/v1_1.hpp
@@ -43,17 +43,30 @@ enum class BurnAfterUse
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/configure_one_time_key"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    ResponseData() :
+        one_time_key_request_count(0)
+    {}
+    /** API response field "response.one_time_key_request_count" */
+    uint32_t one_time_key_request_count;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/configure_one_time_key"
  */
 class Response : public ResponseBase
 {
 public:
-    Response() :
-        one_time_key_request_count(0)
-    {}
-    /** API response field "response.one_time_key_request_count" */
-    uint32_t one_time_key_request_count;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -133,7 +146,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/configure_one_time_key/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/configure_one_time_key/v1_3.cpp
@@ -104,13 +104,21 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->one_time_key_request_count = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->one_time_key_request_count = 0;
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_key_request_count",
-            &response->one_time_key_request_count);
+            &response_data_ptr->one_time_key_request_count);
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/configure_one_time_key/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/configure_one_time_key/v1_3.hpp
@@ -43,17 +43,30 @@ enum class BurnAfterUse
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/configure_one_time_key"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    ResponseData() :
+        one_time_key_request_count(0)
+    {}
+    /** API response field "response.one_time_key_request_count" */
+    uint32_t one_time_key_request_count;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/configure_one_time_key"
  */
 class Response : public ResponseBase
 {
 public:
-    Response() :
-        one_time_key_request_count(0)
-    {}
-    /** API response field "response.one_time_key_request_count" */
-    uint32_t one_time_key_request_count;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -133,7 +146,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/copy/v0.cpp
+++ b/src/mediafire_sdk/api/file/copy/v0.cpp
@@ -81,11 +81,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
@@ -94,10 +99,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExistsArrayFront(
             response->pt,
             "response.new_quickkeys",
-            &response->quickkey ) )
+            &response_data_ptr->quickkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.new_quickkeys\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/copy/v0.hpp
+++ b/src/mediafire_sdk/api/file/copy/v0.hpp
@@ -27,10 +27,12 @@ namespace copy {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "file/copy"
+ * @class ResponseData
+ * @brief Response data from API request "file/copy"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.device_revision" */
@@ -38,6 +40,17 @@ public:
 
     /** API response field "response.new_quickkeys" */
     std::string quickkey;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/copy"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -68,7 +81,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/copy/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/copy/v1_3.cpp
@@ -81,6 +81,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -89,7 +94,7 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
 
@@ -97,10 +102,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExistsArrayFront(
             response->pt,
             "response.new_quickkeys",
-            &response->quickkey ) )
+            &response_data_ptr->quickkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.new_quickkeys\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/copy/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/copy/v1_3.hpp
@@ -27,10 +27,12 @@ namespace copy {
 namespace v1_3 {
 
 /**
- * @class Response
- * @brief Response from API request "file/copy"
+ * @class ResponseData
+ * @brief Response data from API request "file/copy"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.new_device_revision" */
@@ -38,6 +40,17 @@ public:
 
     /** API response field "response.new_quickkeys" */
     std::string quickkey;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/copy"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -68,7 +81,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/create/v0.cpp
+++ b/src/mediafire_sdk/api/file/create/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool LinksFromPropertyBranch(
         Response * response,
-        Response::Links * value,
+        ResponseData::Links * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -140,11 +140,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
@@ -153,7 +158,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.fileinfo.quickkey",
-            &response->quickkey ) )
+            &response_data_ptr->quickkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.quickkey\"");
@@ -162,7 +167,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.fileinfo.filename",
-            &response->filename ) )
+            &response_data_ptr->filename ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.filename\"");
@@ -171,7 +176,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.fileinfo.created",
-            &response->created_datetime ) )
+            &response_data_ptr->created_datetime ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.created\"");
@@ -180,7 +185,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.fileinfo.size",
-            &response->filesize ) )
+            &response_data_ptr->filesize ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.size\"");
@@ -189,7 +194,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.fileinfo.filetype",
-            &response->filetype ) )
+            &response_data_ptr->filetype ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.filetype\"");
@@ -198,7 +203,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.fileinfo.flag",
-            &response->flag ) )
+            &response_data_ptr->flag ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.flag\"");
@@ -208,11 +213,11 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.fileinfo.links");
 
-        Response::Links optarg;
+        ResponseData::Links optarg;
         if ( LinksFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->links = std::move(optarg);
+            response_data_ptr->links = std::move(optarg);
         }
         else
         {
@@ -231,6 +236,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.fileinfo.links\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/create/v0.hpp
+++ b/src/mediafire_sdk/api/file/create/v0.hpp
@@ -27,10 +27,12 @@ namespace create {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "file/create"
+ * @class ResponseData
+ * @brief Response data from API request "file/create"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Links
@@ -67,6 +69,17 @@ public:
 
     /** API response field "response.fileinfo.links" */
     Links links;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/create"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -114,7 +127,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/create/v1_2.hpp
+++ b/src/mediafire_sdk/api/file/create/v1_2.hpp
@@ -51,13 +51,15 @@ enum class Privacy
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/create"
+ * @class ResponseData
+ * @brief Response data from API request "file/create"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         description(""),
         mimetype("")
     {}
@@ -145,6 +147,17 @@ public:
     std::string quickkey;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "file/create"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -203,7 +216,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/create/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/create/v1_3.hpp
@@ -51,13 +51,15 @@ enum class Privacy
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/create"
+ * @class ResponseData
+ * @brief Response data from API request "file/create"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         description(""),
         mimetype("")
     {}
@@ -145,6 +147,17 @@ public:
     std::string quickkey;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "file/create"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -203,7 +216,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/file_delete/v0.cpp
+++ b/src/mediafire_sdk/api/file/file_delete/v0.cpp
@@ -80,14 +80,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/file_delete/v0.hpp
+++ b/src/mediafire_sdk/api/file/file_delete/v0.hpp
@@ -27,14 +27,27 @@ namespace file_delete {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/delete"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    uint32_t device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/delete"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    uint32_t device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -58,7 +71,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/file_delete/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/file_delete/v1_3.cpp
@@ -80,6 +80,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -88,9 +93,12 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/file_delete/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/file_delete/v1_3.hpp
@@ -27,14 +27,27 @@ namespace file_delete {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/delete"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.new_device_revision" */
+    boost::optional<uint32_t> new_device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/delete"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.new_device_revision" */
-    boost::optional<uint32_t> new_device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -58,7 +71,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/get_info/v0.hpp
+++ b/src/mediafire_sdk/api/file/get_info/v0.hpp
@@ -67,13 +67,15 @@ enum class Permission
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/get_info"
+ * @class ResponseData
+ * @brief Response data from API request "file/get_info"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         deleted_datetime(boost::posix_time::not_a_date_time),
         mimetype(""),
         shared_by_user(SharedByUser::Unshared)
@@ -144,6 +146,17 @@ public:
     uint32_t flag;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "file/get_info"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -173,7 +186,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/get_info/v1_1.hpp
+++ b/src/mediafire_sdk/api/file/get_info/v1_1.hpp
@@ -67,13 +67,15 @@ enum class SharedByUser
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/get_info"
+ * @class ResponseData
+ * @brief Response data from API request "file/get_info"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         deleted_datetime(boost::posix_time::not_a_date_time),
         mimetype(""),
         shared_by_user(SharedByUser::Unshared)
@@ -185,6 +187,17 @@ public:
     Links links;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "file/get_info"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -214,7 +227,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/get_links/v0.hpp
+++ b/src/mediafire_sdk/api/file/get_links/v0.hpp
@@ -54,13 +54,15 @@ enum class LinkType
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/get_links"
+ * @class ResponseData
+ * @brief Response data from API request "file/get_links"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         one_time_download_request_count(0),
         direct_download_free_bandwidth(0)
     {}
@@ -115,6 +117,17 @@ public:
     uint32_t direct_download_free_bandwidth;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "file/get_links"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -148,7 +161,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/get_links/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/get_links/v1_3.cpp
@@ -48,7 +48,7 @@ namespace {
 using namespace v1_3;  // NOLINT
 bool LinksFromPropertyBranch(
         Response * response,
-        Response::Links * value,
+        ResponseData::Links * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -328,21 +328,26 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->one_time_download_request_count = 0;
-    response->direct_download_free_bandwidth = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->one_time_download_request_count = 0;
+    response_data_ptr->direct_download_free_bandwidth = 0;
 
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.links");
-        response->links.reserve( response->pt.size() );
+        response_data_ptr->links.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Links optarg;
+            ResponseData::Links optarg;
             if ( LinksFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->links.push_back(std::move(optarg));
+                response_data_ptr->links.push_back(std::move(optarg));
             else
                 return;  // error set already
         }
@@ -360,13 +365,16 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.one_time_download_request_count",
-            &response->one_time_download_request_count);
+            &response_data_ptr->one_time_download_request_count);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.direct_download_free_bandwidth",
-            &response->direct_download_free_bandwidth);
+            &response_data_ptr->direct_download_free_bandwidth);
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/get_links/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/get_links/v1_3.hpp
@@ -54,13 +54,15 @@ enum class LinkType
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/get_links"
+ * @class ResponseData
+ * @brief Response data from API request "file/get_links"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         one_time_download_request_count(0),
         direct_download_free_bandwidth(0)
     {}
@@ -127,6 +129,17 @@ public:
     uint32_t direct_download_free_bandwidth;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "file/get_links"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -160,7 +173,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/get_versions/v0.cpp
+++ b/src/mediafire_sdk/api/file/get_versions/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool FileVersionFromPropertyBranch(
         Response * response,
-        Response::FileVersion * value,
+        ResponseData::FileVersion * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -140,24 +140,32 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.file_versions");
-        response->file_versions.reserve( response->pt.size() );
+        response_data_ptr->file_versions.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::FileVersion optarg;
+            ResponseData::FileVersion optarg;
             if ( FileVersionFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->file_versions.push_back(std::move(optarg));
+                response_data_ptr->file_versions.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/get_versions/v0.hpp
+++ b/src/mediafire_sdk/api/file/get_versions/v0.hpp
@@ -35,10 +35,12 @@ enum class AtHead
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/get_versions"
+ * @class ResponseData
+ * @brief Response data from API request "file/get_versions"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct FileVersion
@@ -54,6 +56,17 @@ public:
     };
     /** API response field "response.file_versions" */
     std::vector<FileVersion> file_versions;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/get_versions"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -81,7 +94,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/get_versions/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/get_versions/v1_3.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v1_3;  // NOLINT
 bool FileVersionFromPropertyBranch(
         Response * response,
-        Response::FileVersion * value,
+        ResponseData::FileVersion * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -140,24 +140,32 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.file_versions");
-        response->file_versions.reserve( response->pt.size() );
+        response_data_ptr->file_versions.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::FileVersion optarg;
+            ResponseData::FileVersion optarg;
             if ( FileVersionFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->file_versions.push_back(std::move(optarg));
+                response_data_ptr->file_versions.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/get_versions/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/get_versions/v1_3.hpp
@@ -35,10 +35,12 @@ enum class AtHead
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/get_versions"
+ * @class ResponseData
+ * @brief Response data from API request "file/get_versions"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct FileVersion
@@ -54,6 +56,17 @@ public:
     };
     /** API response field "response.file_versions" */
     std::vector<FileVersion> file_versions;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/get_versions"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -81,7 +94,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/move/v0.cpp
+++ b/src/mediafire_sdk/api/file/move/v0.cpp
@@ -84,6 +84,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -92,9 +97,12 @@ void Impl::ParseResponse( Response * response )
                 "response.device_revision",
                 &optarg) )
         {
-            response->device_revision = optarg;
+            response_data_ptr->device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/move/v0.hpp
+++ b/src/mediafire_sdk/api/file/move/v0.hpp
@@ -27,14 +27,27 @@ namespace move {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/move"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    boost::optional<uint32_t> device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/move"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    boost::optional<uint32_t> device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -60,7 +73,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/move/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/move/v1_3.cpp
@@ -84,6 +84,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -92,9 +97,12 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/move/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/move/v1_3.hpp
@@ -27,14 +27,27 @@ namespace move {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/move"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.new_device_revision" */
+    boost::optional<uint32_t> new_device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/move"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.new_device_revision" */
-    boost::optional<uint32_t> new_device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -60,7 +73,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/one_time_key/v1_1.cpp
+++ b/src/mediafire_sdk/api/file/one_time_key/v1_1.cpp
@@ -108,26 +108,31 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->one_time_key_request_count = 0;
-    response->one_time_key_request_max_count = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->one_time_key_request_count = 0;
+    response_data_ptr->one_time_key_request_max_count = 0;
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_key_request_count",
-            &response->one_time_key_request_count);
+            &response_data_ptr->one_time_key_request_count);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_key_request_max_count",
-            &response->one_time_key_request_max_count);
+            &response_data_ptr->one_time_key_request_max_count);
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.token",
-            &response->token ) )
+            &response_data_ptr->token ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.token\"");
@@ -140,7 +145,7 @@ void Impl::ParseResponse( Response * response )
                 "response.links.download",
                 &optarg) )
         {
-            response->download_link = optarg;
+            response_data_ptr->download_link = optarg;
         }
     }
 
@@ -152,7 +157,7 @@ void Impl::ParseResponse( Response * response )
                 "response.links.view",
                 &optarg) )
         {
-            response->view_link = optarg;
+            response_data_ptr->view_link = optarg;
         }
     }
 
@@ -164,7 +169,7 @@ void Impl::ParseResponse( Response * response )
                 "response.links.watch",
                 &optarg) )
         {
-            response->watch_link = optarg;
+            response_data_ptr->watch_link = optarg;
         }
     }
 
@@ -176,9 +181,12 @@ void Impl::ParseResponse( Response * response )
                 "response.links.listen",
                 &optarg) )
         {
-            response->listen_link = optarg;
+            response_data_ptr->listen_link = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/one_time_key/v1_1.hpp
+++ b/src/mediafire_sdk/api/file/one_time_key/v1_1.hpp
@@ -51,13 +51,15 @@ enum class GetCountsOnly
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/one_time_key"
+ * @class ResponseData
+ * @brief Response data from API request "file/one_time_key"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         one_time_key_request_count(0),
         one_time_key_request_max_count(0)
     {}
@@ -81,6 +83,17 @@ public:
 
     /** API response field "response.links.listen" */
     boost::optional<std::string> listen_link;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/one_time_key"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -173,7 +186,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/one_time_key/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/one_time_key/v1_3.cpp
@@ -108,26 +108,31 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->one_time_key_request_count = 0;
-    response->one_time_key_request_max_count = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->one_time_key_request_count = 0;
+    response_data_ptr->one_time_key_request_max_count = 0;
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_key_request_count",
-            &response->one_time_key_request_count);
+            &response_data_ptr->one_time_key_request_count);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_key_request_max_count",
-            &response->one_time_key_request_max_count);
+            &response_data_ptr->one_time_key_request_max_count);
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.token",
-            &response->token ) )
+            &response_data_ptr->token ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.token\"");
@@ -140,7 +145,7 @@ void Impl::ParseResponse( Response * response )
                 "response.links.download",
                 &optarg) )
         {
-            response->download_link = optarg;
+            response_data_ptr->download_link = optarg;
         }
     }
 
@@ -152,7 +157,7 @@ void Impl::ParseResponse( Response * response )
                 "response.links.view",
                 &optarg) )
         {
-            response->view_link = optarg;
+            response_data_ptr->view_link = optarg;
         }
     }
 
@@ -164,7 +169,7 @@ void Impl::ParseResponse( Response * response )
                 "response.links.watch",
                 &optarg) )
         {
-            response->watch_link = optarg;
+            response_data_ptr->watch_link = optarg;
         }
     }
 
@@ -176,9 +181,12 @@ void Impl::ParseResponse( Response * response )
                 "response.links.listen",
                 &optarg) )
         {
-            response->listen_link = optarg;
+            response_data_ptr->listen_link = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/one_time_key/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/one_time_key/v1_3.hpp
@@ -51,13 +51,15 @@ enum class GetCountsOnly
 };
 
 /**
- * @class Response
- * @brief Response from API request "file/one_time_key"
+ * @class ResponseData
+ * @brief Response data from API request "file/one_time_key"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         one_time_key_request_count(0),
         one_time_key_request_max_count(0)
     {}
@@ -81,6 +83,17 @@ public:
 
     /** API response field "response.links.listen" */
     boost::optional<std::string> listen_link;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "file/one_time_key"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -173,7 +186,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/purge/v0.cpp
+++ b/src/mediafire_sdk/api/file/purge/v0.cpp
@@ -80,6 +80,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -88,9 +93,12 @@ void Impl::ParseResponse( Response * response )
                 "response.device_revision",
                 &optarg) )
         {
-            response->device_revision = optarg;
+            response_data_ptr->device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/purge/v0.hpp
+++ b/src/mediafire_sdk/api/file/purge/v0.hpp
@@ -27,14 +27,27 @@ namespace purge {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/purge"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    boost::optional<uint32_t> device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/purge"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    boost::optional<uint32_t> device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -58,7 +71,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/purge/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/purge/v1_3.cpp
@@ -80,6 +80,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -88,9 +93,12 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/purge/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/purge/v1_3.hpp
@@ -27,14 +27,27 @@ namespace purge {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/purge"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.new_device_revision" */
+    boost::optional<uint32_t> new_device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/purge"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.new_device_revision" */
-    boost::optional<uint32_t> new_device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -58,7 +71,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/recently_modified/v0.cpp
+++ b/src/mediafire_sdk/api/file/recently_modified/v0.cpp
@@ -75,11 +75,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_array TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.quickkeys");
-        response->quickkeys.reserve( branch.size() );
+        response_data_ptr->quickkeys.reserve( branch.size() );
         for ( auto & it : branch )
         {
             std::string result;
@@ -87,7 +92,7 @@ void Impl::ParseResponse( Response * response )
                     it.second,
                     &result ) )
             {
-                response->quickkeys.push_back(result);
+                response_data_ptr->quickkeys.push_back(result);
             }
             else
             {
@@ -99,6 +104,9 @@ void Impl::ParseResponse( Response * response )
     {
         // The value is optional.
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/recently_modified/v0.hpp
+++ b/src/mediafire_sdk/api/file/recently_modified/v0.hpp
@@ -27,14 +27,27 @@ namespace recently_modified {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/recently_modified"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.quickkeys" */
+    std::vector<std::string> quickkeys;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/recently_modified"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.quickkeys" */
-    std::vector<std::string> quickkeys;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -61,7 +74,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/recently_modified/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/recently_modified/v1_3.cpp
@@ -75,11 +75,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_array TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.quickkeys");
-        response->quickkeys.reserve( branch.size() );
+        response_data_ptr->quickkeys.reserve( branch.size() );
         for ( auto & it : branch )
         {
             std::string result;
@@ -87,7 +92,7 @@ void Impl::ParseResponse( Response * response )
                     it.second,
                     &result ) )
             {
-                response->quickkeys.push_back(result);
+                response_data_ptr->quickkeys.push_back(result);
             }
             else
             {
@@ -99,6 +104,9 @@ void Impl::ParseResponse( Response * response )
     {
         // The value is optional.
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/recently_modified/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/recently_modified/v1_3.hpp
@@ -27,14 +27,27 @@ namespace recently_modified {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/recently_modified"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.quickkeys" */
+    std::vector<std::string> quickkeys;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/recently_modified"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.quickkeys" */
-    std::vector<std::string> quickkeys;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -61,7 +74,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/restore/v0.cpp
+++ b/src/mediafire_sdk/api/file/restore/v0.cpp
@@ -83,7 +83,12 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->asynchronous = Asynchronous::Synchronous;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->asynchronous = Asynchronous::Synchronous;
 
     {
         std::string optval;
@@ -94,11 +99,14 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->asynchronous = Asynchronous::Synchronous;
+                response_data_ptr->asynchronous = Asynchronous::Synchronous;
             else if ( optval == "yes" )
-                response->asynchronous = Asynchronous::Asynchronous;
+                response_data_ptr->asynchronous = Asynchronous::Asynchronous;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/restore/v0.hpp
+++ b/src/mediafire_sdk/api/file/restore/v0.hpp
@@ -35,17 +35,30 @@ enum class Asynchronous
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/restore"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    ResponseData() :
+        asynchronous(Asynchronous::Synchronous)
+    {}
+    /** API response field "response.asynchronous" */
+    Asynchronous asynchronous;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/restore"
  */
 class Response : public ResponseBase
 {
 public:
-    Response() :
-        asynchronous(Asynchronous::Synchronous)
-    {}
-    /** API response field "response.asynchronous" */
-    Asynchronous asynchronous;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -75,7 +88,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/restore/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/restore/v1_3.cpp
@@ -83,7 +83,12 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->asynchronous = Asynchronous::Synchronous;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->asynchronous = Asynchronous::Synchronous;
 
     {
         std::string optval;
@@ -94,11 +99,14 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->asynchronous = Asynchronous::Synchronous;
+                response_data_ptr->asynchronous = Asynchronous::Synchronous;
             else if ( optval == "yes" )
-                response->asynchronous = Asynchronous::Asynchronous;
+                response_data_ptr->asynchronous = Asynchronous::Asynchronous;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/restore/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/restore/v1_3.hpp
@@ -35,17 +35,30 @@ enum class Asynchronous
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/restore"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    ResponseData() :
+        asynchronous(Asynchronous::Synchronous)
+    {}
+    /** API response field "response.asynchronous" */
+    Asynchronous asynchronous;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/restore"
  */
 class Response : public ResponseBase
 {
 public:
-    Response() :
-        asynchronous(Asynchronous::Synchronous)
-    {}
-    /** API response field "response.asynchronous" */
-    Asynchronous asynchronous;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -75,7 +88,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/update/v0.cpp
+++ b/src/mediafire_sdk/api/file/update/v0.cpp
@@ -95,6 +95,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -103,9 +108,12 @@ void Impl::ParseResponse( Response * response )
                 "response.device_revision",
                 &optarg) )
         {
-            response->device_revision = optarg;
+            response_data_ptr->device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/update/v0.hpp
+++ b/src/mediafire_sdk/api/file/update/v0.hpp
@@ -35,14 +35,27 @@ enum class Privacy
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/update"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    boost::optional<uint32_t> device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/update"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    boost::optional<uint32_t> device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -98,7 +111,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/update/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/update/v1_3.cpp
@@ -95,6 +95,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -103,9 +108,12 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/update/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/update/v1_3.hpp
@@ -35,14 +35,27 @@ enum class Privacy
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/update"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.new_device_revision" */
+    boost::optional<uint32_t> new_device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/update"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.new_device_revision" */
-    boost::optional<uint32_t> new_device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -98,7 +111,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/update_file/v0.cpp
+++ b/src/mediafire_sdk/api/file/update_file/v0.cpp
@@ -84,6 +84,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -92,9 +97,12 @@ void Impl::ParseResponse( Response * response )
                 "response.device_revision",
                 &optarg) )
         {
-            response->device_revision = optarg;
+            response_data_ptr->device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/update_file/v0.hpp
+++ b/src/mediafire_sdk/api/file/update_file/v0.hpp
@@ -27,14 +27,27 @@ namespace update_file {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/update_file"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.device_revision" */
+    boost::optional<uint32_t> device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/update_file"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.device_revision" */
-    boost::optional<uint32_t> device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -60,7 +73,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/file/update_file/v1_3.cpp
+++ b/src/mediafire_sdk/api/file/update_file/v1_3.cpp
@@ -84,6 +84,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         uint32_t optarg;
@@ -92,9 +97,12 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/file/update_file/v1_3.hpp
+++ b/src/mediafire_sdk/api/file/update_file/v1_3.hpp
@@ -27,14 +27,27 @@ namespace update_file {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "file/update_file"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.new_device_revision" */
+    boost::optional<uint32_t> new_device_revision;
+};
+
+/**
  * @class Response
  * @brief Response from API request "file/update_file"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.new_device_revision" */
-    boost::optional<uint32_t> new_device_revision;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -60,7 +73,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/copy/v0.cpp
+++ b/src/mediafire_sdk/api/folder/copy/v0.cpp
@@ -83,7 +83,12 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->asynchronous = Asynchronous::Synchronous;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->asynchronous = Asynchronous::Synchronous;
 
     {
         std::string optval;
@@ -94,9 +99,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->asynchronous = Asynchronous::Synchronous;
+                response_data_ptr->asynchronous = Asynchronous::Synchronous;
             else if ( optval == "yes" )
-                response->asynchronous = Asynchronous::Asynchronous;
+                response_data_ptr->asynchronous = Asynchronous::Asynchronous;
         }
     }
 
@@ -104,7 +109,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
@@ -113,10 +118,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExistsArrayFront(
             response->pt,
             "response.new_folderkeys",
-            &response->folderkey ) )
+            &response_data_ptr->folderkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.new_folderkeys\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/folder/copy/v0.hpp
+++ b/src/mediafire_sdk/api/folder/copy/v0.hpp
@@ -35,13 +35,15 @@ enum class Asynchronous
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/copy"
+ * @class ResponseData
+ * @brief Response data from API request "folder/copy"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         asynchronous(Asynchronous::Synchronous)
     {}
     /** API response field "response.asynchronous" */
@@ -52,6 +54,17 @@ public:
 
     /** API response field "response.new_folderkeys" */
     std::string folderkey;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "folder/copy"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -81,7 +94,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/create/v0.cpp
+++ b/src/mediafire_sdk/api/folder/create/v0.cpp
@@ -94,11 +94,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.folder_key",
-            &response->folderkey ) )
+            &response_data_ptr->folderkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.folder_key\"");
@@ -107,7 +112,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.upload_key",
-            &response->uploadkey ) )
+            &response_data_ptr->uploadkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.upload_key\"");
@@ -116,7 +121,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.name",
-            &response->name ) )
+            &response_data_ptr->name ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.name\"");
@@ -125,7 +130,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.created",
-            &response->created_datetime ) )
+            &response_data_ptr->created_datetime ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.created\"");
@@ -139,9 +144,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "public" )
-                response->privacy = Privacy::Public;
+                response_data_ptr->privacy = Privacy::Public;
             else if ( optval == "private" )
-                response->privacy = Privacy::Private;
+                response_data_ptr->privacy = Privacy::Private;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -157,10 +162,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.revision",
-            &response->revision ) )
+            &response_data_ptr->revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/folder/create/v0.hpp
+++ b/src/mediafire_sdk/api/folder/create/v0.hpp
@@ -51,10 +51,12 @@ enum class Privacy
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/create"
+ * @class ResponseData
+ * @brief Response data from API request "folder/create"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.folder_key" */
@@ -74,6 +76,17 @@ public:
 
     /** API response field "response.revision" */
     uint32_t revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "folder/create"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -125,7 +138,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/folder_delete/v0.cpp
+++ b/src/mediafire_sdk/api/folder/folder_delete/v0.cpp
@@ -79,7 +79,12 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->asynchronous = Asynchronous::Synchronous;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->asynchronous = Asynchronous::Synchronous;
 
     {
         std::string optval;
@@ -90,9 +95,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->asynchronous = Asynchronous::Synchronous;
+                response_data_ptr->asynchronous = Asynchronous::Synchronous;
             else if ( optval == "yes" )
-                response->asynchronous = Asynchronous::Asynchronous;
+                response_data_ptr->asynchronous = Asynchronous::Asynchronous;
         }
     }
 
@@ -100,10 +105,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.device_revision",
-            &response->device_revision ) )
+            &response_data_ptr->device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.device_revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/folder/folder_delete/v0.hpp
+++ b/src/mediafire_sdk/api/folder/folder_delete/v0.hpp
@@ -35,13 +35,15 @@ enum class Asynchronous
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/delete"
+ * @class ResponseData
+ * @brief Response data from API request "folder/delete"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         asynchronous(Asynchronous::Synchronous)
     {}
     /** API response field "response.asynchronous" */
@@ -49,6 +51,17 @@ public:
 
     /** API response field "response.device_revision" */
     uint32_t device_revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "folder/delete"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -76,7 +89,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/get_content/v0.cpp
+++ b/src/mediafire_sdk/api/folder/get_content/v0.cpp
@@ -68,7 +68,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool LinksFromPropertyBranch(
         Response * response,
-        Response::Links * value,
+        ResponseData::Links * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -151,7 +151,7 @@ bool LinksFromPropertyBranch(
 using namespace v0;  // NOLINT
 bool PermissionsFromPropertyBranch(
         Response * response,
-        Response::Permissions * value,
+        ResponseData::Permissions * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -252,7 +252,7 @@ bool PermissionsFromPropertyBranch(
 using namespace v0;  // NOLINT
 bool FileFromPropertyBranch(
         Response * response,
-        Response::File * value,
+        ResponseData::File * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -357,7 +357,7 @@ bool FileFromPropertyBranch(
         const boost::property_tree::wptree & branch =
             pt.get_child(L"links");
 
-        Response::Links optarg;
+        ResponseData::Links optarg;
         if ( LinksFromPropertyBranch(
                 response, &optarg, branch) )
         {
@@ -415,7 +415,7 @@ bool FileFromPropertyBranch(
         const boost::property_tree::wptree & branch =
             pt.get_child(L"permissions");
 
-        Response::Permissions optarg;
+        ResponseData::Permissions optarg;
         if ( PermissionsFromPropertyBranch(
                 response, &optarg, branch) )
         {
@@ -515,7 +515,7 @@ bool FileFromPropertyBranch(
 using namespace v0;  // NOLINT
 bool FolderFromPropertyBranch(
         Response * response,
-        Response::Folder * value,
+        ResponseData::Folder * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -633,7 +633,7 @@ bool FolderFromPropertyBranch(
         const boost::property_tree::wptree & branch =
             pt.get_child(L"permissions");
 
-        Response::Permissions optarg;
+        ResponseData::Permissions optarg;
         if ( PermissionsFromPropertyBranch(
                 response, &optarg, branch) )
         {
@@ -832,11 +832,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.folder_content.chunk_size",
-            &response->chunk_size ) )
+            &response_data_ptr->chunk_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.folder_content.chunk_size\"");
@@ -850,9 +855,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "folders" )
-                response->content_type = ContentType::Folders;
+                response_data_ptr->content_type = ContentType::Folders;
             else if ( optval == "files" )
-                response->content_type = ContentType::Files;
+                response_data_ptr->content_type = ContentType::Files;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -868,7 +873,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.folder_content.chunk_number",
-            &response->chunk_number ) )
+            &response_data_ptr->chunk_number ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.folder_content.chunk_number\"");
@@ -877,14 +882,14 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.folder_content.files");
-        response->files.reserve( response->pt.size() );
+        response_data_ptr->files.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::File optarg;
+            ResponseData::File optarg;
             if ( FileFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->files.push_back(std::move(optarg));
+                response_data_ptr->files.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -896,20 +901,23 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.folder_content.folders");
-        response->folders.reserve( response->pt.size() );
+        response_data_ptr->folders.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::Folder optarg;
+            ResponseData::Folder optarg;
             if ( FolderFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->folders.push_back(std::move(optarg));
+                response_data_ptr->folders.push_back(std::move(optarg));
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/folder/get_content/v0.hpp
+++ b/src/mediafire_sdk/api/folder/get_content/v0.hpp
@@ -121,10 +121,12 @@ enum class Permission
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/get_content"
+ * @class ResponseData
+ * @brief Response data from API request "folder/get_content"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Links
@@ -289,6 +291,17 @@ public:
     std::vector<Folder> folders;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "folder/get_content"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -363,7 +376,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/get_content/v1_2.hpp
+++ b/src/mediafire_sdk/api/folder/get_content/v1_2.hpp
@@ -129,10 +129,12 @@ enum class ChunksRemaining
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/get_content"
+ * @class ResponseData
+ * @brief Response data from API request "folder/get_content"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Links
@@ -300,6 +302,17 @@ public:
     std::vector<Folder> folders;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "folder/get_content"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -382,7 +395,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/get_info/v0.hpp
+++ b/src/mediafire_sdk/api/folder/get_info/v0.hpp
@@ -69,13 +69,15 @@ enum class Permission
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/get_info"
+ * @class ResponseData
+ * @brief Response data from API request "folder/get_info"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         created_datetime(boost::posix_time::not_a_date_time),
         deleted_datetime(boost::posix_time::not_a_date_time),
         shared_by_user(SharedByUser::Unshared)
@@ -155,6 +157,17 @@ public:
     uint32_t revision;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "folder/get_info"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -198,7 +211,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/move/v0.cpp
+++ b/src/mediafire_sdk/api/folder/move/v0.cpp
@@ -83,7 +83,12 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->asynchronous = Asynchronous::Synchronous;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->asynchronous = Asynchronous::Synchronous;
 
     {
         std::string optval;
@@ -94,9 +99,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->asynchronous = Asynchronous::Synchronous;
+                response_data_ptr->asynchronous = Asynchronous::Synchronous;
             else if ( optval == "yes" )
-                response->asynchronous = Asynchronous::Asynchronous;
+                response_data_ptr->asynchronous = Asynchronous::Asynchronous;
         }
     }
 
@@ -108,9 +113,12 @@ void Impl::ParseResponse( Response * response )
                 "response.device_revision",
                 &optarg) )
         {
-            response->device_revision = optarg;
+            response_data_ptr->device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/folder/move/v0.hpp
+++ b/src/mediafire_sdk/api/folder/move/v0.hpp
@@ -35,13 +35,15 @@ enum class Asynchronous
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/move"
+ * @class ResponseData
+ * @brief Response data from API request "folder/move"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         asynchronous(Asynchronous::Synchronous)
     {}
     /** API response field "response.asynchronous" */
@@ -49,6 +51,17 @@ public:
 
     /** API response field "response.device_revision" */
     boost::optional<uint32_t> device_revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "folder/move"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -78,7 +91,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/folder/update/v0.cpp
+++ b/src/mediafire_sdk/api/folder/update/v0.cpp
@@ -103,7 +103,12 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->asynchronous = Asynchronous::Synchronous;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->asynchronous = Asynchronous::Synchronous;
 
     {
         std::string optval;
@@ -114,9 +119,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->asynchronous = Asynchronous::Synchronous;
+                response_data_ptr->asynchronous = Asynchronous::Synchronous;
             else if ( optval == "yes" )
-                response->asynchronous = Asynchronous::Asynchronous;
+                response_data_ptr->asynchronous = Asynchronous::Asynchronous;
         }
     }
 
@@ -128,9 +133,12 @@ void Impl::ParseResponse( Response * response )
                 "response.device_revision",
                 &optarg) )
         {
-            response->device_revision = optarg;
+            response_data_ptr->device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/folder/update/v0.hpp
+++ b/src/mediafire_sdk/api/folder/update/v0.hpp
@@ -51,13 +51,15 @@ enum class PrivacyRecursive
 };
 
 /**
- * @class Response
- * @brief Response from API request "folder/update"
+ * @class ResponseData
+ * @brief Response data from API request "folder/update"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         asynchronous(Asynchronous::Synchronous)
     {}
     /** API response field "response.asynchronous" */
@@ -65,6 +67,17 @@ public:
 
     /** API response field "response.device_revision" */
     boost::optional<uint32_t> device_revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "folder/update"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -130,7 +143,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/notifications/get_cache/v0.hpp
+++ b/src/mediafire_sdk/api/notifications/get_cache/v0.hpp
@@ -35,10 +35,12 @@ enum class Viewable
 };
 
 /**
- * @class Response
- * @brief Response from API request "notifications/get_cache"
+ * @class ResponseData
+ * @brief Response data from API request "notifications/get_cache"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct Notification
@@ -63,6 +65,17 @@ public:
 
     /** API response field "response.num_older" */
     uint32_t number_older;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "notifications/get_cache"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -100,7 +113,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/notifications/peek_cache/v0.cpp
+++ b/src/mediafire_sdk/api/notifications/peek_cache/v0.cpp
@@ -74,11 +74,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.num_total",
-            &response->total ) )
+            &response_data_ptr->total ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.num_total\"");
@@ -87,7 +92,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.num_unread",
-            &response->unread ) )
+            &response_data_ptr->unread ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.num_unread\"");
@@ -96,10 +101,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.last_timestamp",
-            &response->last_timestamp ) )
+            &response_data_ptr->last_timestamp ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.last_timestamp\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/notifications/peek_cache/v0.hpp
+++ b/src/mediafire_sdk/api/notifications/peek_cache/v0.hpp
@@ -27,10 +27,12 @@ namespace peek_cache {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "notifications/peek_cache"
+ * @class ResponseData
+ * @brief Response data from API request "notifications/peek_cache"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.num_total" */
@@ -41,6 +43,17 @@ public:
 
     /** API response field "response.last_timestamp" */
     uint64_t last_timestamp;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "notifications/peek_cache"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -60,7 +73,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/session_maintainer.cpp
+++ b/src/mediafire_sdk/api/session_maintainer.cpp
@@ -24,7 +24,7 @@
 #include "mediafire_sdk/api/error.hpp"
 #include "mediafire_sdk/utils/variant_comparison.hpp"
 
-#if ! defined(NDEBUG)
+#if !defined(NDEBUG)
 // Counter to keep track of number of HttpRequests
 boost::atomic<int> mf::api::detail::session_maintainer_request_count(0);
 #endif
@@ -34,7 +34,8 @@ namespace hl = mf::http;
 using mf::api::detail::STRequest;
 using mf::api::detail::SessionMaintainerRequest;
 
-namespace {
+namespace
+{
 namespace session_state = mf::api::session_state;
 using mf::api::SessionState;
 
@@ -74,12 +75,14 @@ bool IsUnconnected(const ConnectionState & state)
 }
 }  // namespace
 
-namespace mf {
-namespace api {
+namespace mf
+{
+namespace api
+{
 
 SessionMaintainer::SessionMaintainer(
-        mf::http::HttpConfig::ConstPointer http_config
-    ) : SessionMaintainer(http_config, "www.mediafire.com")
+        mf::http::HttpConfig::ConstPointer http_config)
+        : SessionMaintainer(http_config, "www.mediafire.com")
 {
 }
 
@@ -195,15 +198,13 @@ void SessionMaintainer::UpdateConnectionStateFromErrorCode(
 
     // Check for errors that we count as connection errors
     if (ec.category() == hl::http_category()
-        && (    ec == http_error::UnableToConnect
-            ||  ec == http_error::UnableToConnectToProxy
-            ||  ec == http_error::UnableToResolve
-            ||  ec == http_error::SslHandshakeFailure
-            ||  ec == http_error::WriteFailure
-            ||  ec == http_error::ReadFailure
-            ||  ec == http_error::ProxyProtocolFailure
-            ||  ec == http_error::IoTimeout
-        ))
+        && (ec == http_error::UnableToConnect
+            || ec == http_error::UnableToConnectToProxy
+            || ec == http_error::UnableToResolve
+            || ec == http_error::SslHandshakeFailure
+            || ec == http_error::WriteFailure || ec == http_error::ReadFailure
+            || ec == http_error::ProxyProtocolFailure
+            || ec == http_error::IoTimeout))
     {
         connection_state::Unconnected new_state = {ec};
 
@@ -211,11 +212,10 @@ void SessionMaintainer::UpdateConnectionStateFromErrorCode(
 
         // State is disconnected, so schedule a state check later
         connection_state_recheck_timer_.expires_from_now(
-                std::chrono::milliseconds(
-                        connection_state_recheck_timeout_ms));
+                std::chrono::milliseconds(connection_state_recheck_timeout_ms));
         connection_state_recheck_timer_.async_wait(boost::bind(
-                &SessionMaintainer::HandleConnectionStateRecheckTimeout,
-                this, boost::asio::placeholders::error));
+                &SessionMaintainer::HandleConnectionStateRecheckTimeout, this,
+                boost::asio::placeholders::error));
     }
     else
     {
@@ -285,7 +285,8 @@ void SessionMaintainer::AttemptConnection()
     auto maintainer_exists = maintainer_exists_;
 
 #if defined(OUTPUT_DEBUG) || defined(DEBUG_API_CONNECTION)
-    std::cout << "SessionMaintainer: Checking connection by calling system/get_status.\n";
+    std::cout << "SessionMaintainer: Checking connection by calling "
+                 "system/get_status.\n";
 #endif
 
     hl::HttpRequest::Pointer http_request = requester_.Call(
@@ -305,8 +306,8 @@ void SessionMaintainer::HandleCheckConnectionStatusResponse(
 {
 #if defined(OUTPUT_DEBUG) || defined(DEBUG_API_CONNECTION)
     std::cout << "SessionMaintainer: system/get_status response: "
-            << response.error_code.message() << "\n" << response.debug
-            << std::endl;
+              << response.error_code.message() << "\n" << response.debug
+              << std::endl;
 #endif
 
     UpdateConnectionStateFromErrorCode(response.error_code);
@@ -445,8 +446,8 @@ void SessionMaintainer::HandleSessionTokenResponse(
 
                     // If the pkey was sent, then the password may have been
                     // changed.  Let the class user figure this out if so.
-                    if (!response.pkey.empty())
-                        new_state.pkey = response.pkey;
+                    if (!response.pkey)
+                        new_state.pkey = *response.pkey;
 
                     // This async call used the same credentials we currently
                     // have!  This means the username and password is bad.
@@ -504,13 +505,12 @@ void SessionMaintainer::HandleSessionTokenResponse(
         std::cout << "SessionMaintainer: Session token request success."
                   << std::endl;
 #endif
+        const auto & data = *response.response_data;
 
         locker_->ResetFailureCount();
 
-        SessionTokenData st = {response.session_token,
-                               response.pkey,
-                               response.time,
-                               response.secret_key};
+        SessionTokenData st = {
+                data.session_token, response.pkey, data.time, data.secret_key};
 
         if (locker_->AddSessionToken(std::move(st), old_credentials))
         {

--- a/src/mediafire_sdk/api/session_maintainer.cpp
+++ b/src/mediafire_sdk/api/session_maintainer.cpp
@@ -446,7 +446,7 @@ void SessionMaintainer::HandleSessionTokenResponse(
 
                     // If the pkey was sent, then the password may have been
                     // changed.  Let the class user figure this out if so.
-                    if (!response.pkey)
+                    if (response.pkey)
                         new_state.pkey = *response.pkey;
 
                     // This async call used the same credentials we currently

--- a/src/mediafire_sdk/api/session_state.cpp
+++ b/src/mediafire_sdk/api/session_state.cpp
@@ -54,7 +54,7 @@ bool operator==(const Running & lhs, const Running & rhs)
 
     if (!l.response_data && !r.response_data)
     {
-        return true;
+        return l.pkey == r.pkey;
     }
     else if (!l.response_data)
     {

--- a/src/mediafire_sdk/api/session_state.cpp
+++ b/src/mediafire_sdk/api/session_state.cpp
@@ -52,11 +52,26 @@ bool operator==(const Running & lhs, const Running & rhs)
     const api::user::get_session_token::Response & r
             = rhs.session_token_response;
 
-    // Only the parts we care about determine if the session token response is
-    // different than another.
+    if (!l.response_data && !r.response_data)
+    {
+        return true;
+    }
+    else if (!l.response_data)
+    {
+        return false;
+    }
+    else if (!r.response_data)
+    {
+        return false;
+    }
+    else
+    {
+        // Only the parts we care about determine if the session token response
+        // is different than another.
 
-    return std::tie(l.session_token, l.pkey)
-           == std::tie(r.session_token, r.pkey);
+        return std::tie(l.response_data->session_token, l.pkey)
+               == std::tie(r.response_data->session_token, r.pkey);
+    }
 }
 
 }  // namespace session_state

--- a/src/mediafire_sdk/api/system/get_editable_media/v0.cpp
+++ b/src/mediafire_sdk/api/system/get_editable_media/v0.cpp
@@ -72,11 +72,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_array TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.editable.extensions");
-        response->editable_extensions.reserve( branch.size() );
+        response_data_ptr->editable_extensions.reserve( branch.size() );
         if (branch.empty())
         {
             return_error(
@@ -90,7 +95,7 @@ void Impl::ParseResponse( Response * response )
                     it.second,
                     &result ) )
             {
-                response->editable_extensions.push_back(result);
+                response_data_ptr->editable_extensions.push_back(result);
             }
             else
             {
@@ -108,6 +113,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.editable.extensions\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/system/get_editable_media/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_editable_media/v0.hpp
@@ -26,14 +26,27 @@ namespace get_editable_media {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "system/get_editable_media"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.editable.extensions" */
+    std::vector<std::string> editable_extensions;
+};
+
+/**
  * @class Response
  * @brief Response from API request "system/get_editable_media"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.editable.extensions" */
-    std::vector<std::string> editable_extensions;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -53,7 +66,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/system/get_info/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_info/v0.hpp
@@ -26,10 +26,12 @@ namespace get_info {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "system/get_info"
+ * @class ResponseData
+ * @brief Response data from API request "system/get_info"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct ImageSize
@@ -85,6 +87,17 @@ public:
     uint64_t max_image_size;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "system/get_info"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -102,7 +115,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/system/get_limits/v0.cpp
+++ b/src/mediafire_sdk/api/system/get_limits/v0.cpp
@@ -72,11 +72,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.limits.max_objects",
-            &response->max_objects ) )
+            &response_data_ptr->max_objects ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.max_objects\"");
@@ -85,7 +90,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.max_keys",
-            &response->max_keys ) )
+            &response_data_ptr->max_keys ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.max_keys\"");
@@ -94,7 +99,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.max_image_size",
-            &response->max_image_size ) )
+            &response_data_ptr->max_image_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.max_image_size\"");
@@ -103,7 +108,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.zip_max_filesize",
-            &response->zip_max_filesize ) )
+            &response_data_ptr->zip_max_filesize ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.zip_max_filesize\"");
@@ -112,7 +117,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.zip_max_total_filesize",
-            &response->zip_max_total_filesize ) )
+            &response_data_ptr->zip_max_total_filesize ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.zip_max_total_filesize\"");
@@ -121,7 +126,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.folder_content_chunk_size",
-            &response->folder_content_chunk_size ) )
+            &response_data_ptr->folder_content_chunk_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.folder_content_chunk_size\"");
@@ -130,7 +135,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.folder_depth_limit",
-            &response->folder_depth_limit ) )
+            &response_data_ptr->folder_depth_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.folder_depth_limit\"");
@@ -139,7 +144,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.limit_search_results",
-            &response->limit_search_results ) )
+            &response_data_ptr->limit_search_results ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.limit_search_results\"");
@@ -148,7 +153,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.daily_shares_limit",
-            &response->daily_shares_limit ) )
+            &response_data_ptr->daily_shares_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.daily_shares_limit\"");
@@ -157,10 +162,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.limits.device_changes_list_limit",
-            &response->device_changes_list_limit ) )
+            &response_data_ptr->device_changes_list_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.limits.device_changes_list_limit\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/system/get_limits/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_limits/v0.hpp
@@ -26,10 +26,12 @@ namespace get_limits {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "system/get_limits"
+ * @class ResponseData
+ * @brief Response data from API request "system/get_limits"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.limits.max_objects" */
@@ -63,6 +65,17 @@ public:
     uint32_t device_changes_list_limit;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "system/get_limits"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -80,7 +93,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/system/get_mime_types/v0.cpp
+++ b/src/mediafire_sdk/api/system/get_mime_types/v0.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool MimeTypeFromPropertyBranch(
         Response * response,
-        Response::MimeType * value,
+        ResponseData::MimeType * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -185,18 +185,23 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.mime_types");
-        response->mimetypes.reserve( response->pt.size() );
+        response_data_ptr->mimetypes.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::MimeType optarg;
+            ResponseData::MimeType optarg;
             if ( MimeTypeFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->mimetypes.push_back(std::move(optarg));
+                response_data_ptr->mimetypes.push_back(std::move(optarg));
             else
                 return;  // error set already
         }
@@ -209,6 +214,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.mime_types\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/system/get_mime_types/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_mime_types/v0.hpp
@@ -74,10 +74,12 @@ enum class EditSystem
 };
 
 /**
- * @class Response
- * @brief Response from API request "system/get_mime_types"
+ * @class ResponseData
+ * @brief Response data from API request "system/get_mime_types"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct MimeType
@@ -99,6 +101,17 @@ public:
     };
     /** API response field "response.mime_types" */
     std::vector<MimeType> mimetypes;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "system/get_mime_types"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -124,7 +137,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/system/get_status/v0.cpp
+++ b/src/mediafire_sdk/api/system/get_status/v0.cpp
@@ -72,11 +72,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.database",
-            &response->database ) )
+            &response_data_ptr->database ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.database\"");
@@ -85,10 +90,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.memcache",
-            &response->memcache ) )
+            &response_data_ptr->memcache ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.memcache\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/system/get_status/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_status/v0.hpp
@@ -26,10 +26,12 @@ namespace get_status {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "system/get_status"
+ * @class ResponseData
+ * @brief Response data from API request "system/get_status"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.database" */
@@ -37,6 +39,17 @@ public:
 
     /** API response field "response.memcache" */
     int32_t memcache;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "system/get_status"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/system/get_supported_media/v0.cpp
+++ b/src/mediafire_sdk/api/system/get_supported_media/v0.cpp
@@ -72,11 +72,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_array TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.viewable.extensions");
-        response->viewable_extensions.reserve( branch.size() );
+        response_data_ptr->viewable_extensions.reserve( branch.size() );
         if (branch.empty())
         {
             return_error(
@@ -90,7 +95,7 @@ void Impl::ParseResponse( Response * response )
                     it.second,
                     &result ) )
             {
-                response->viewable_extensions.push_back(result);
+                response_data_ptr->viewable_extensions.push_back(result);
             }
             else
             {
@@ -108,6 +113,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.viewable.extensions\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/system/get_supported_media/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_supported_media/v0.hpp
@@ -26,14 +26,27 @@ namespace get_supported_media {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "system/get_supported_media"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.viewable.extensions" */
+    std::vector<std::string> viewable_extensions;
+};
+
+/**
  * @class Response
  * @brief Response from API request "system/get_supported_media"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.viewable.extensions" */
-    std::vector<std::string> viewable_extensions;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -53,7 +66,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/system/get_version/v0.cpp
+++ b/src/mediafire_sdk/api/system/get_version/v0.cpp
@@ -72,14 +72,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.current_api_version",
-            &response->current_api_version ) )
+            &response_data_ptr->current_api_version ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.current_api_version\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/system/get_version/v0.hpp
+++ b/src/mediafire_sdk/api/system/get_version/v0.hpp
@@ -26,14 +26,27 @@ namespace get_version {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "system/get_version"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.current_api_version" */
+    std::string current_api_version;
+};
+
+/**
  * @class Response
  * @brief Response from API request "system/get_version"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.current_api_version" */
-    std::string current_api_version;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -53,7 +66,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/templates/api_template.cpp.txt
+++ b/src/mediafire_sdk/api/templates/api_template.cpp.txt
@@ -61,6 +61,7 @@ void Impl::ParseResponse( Response * __PR_OPT_ADT__ )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
+
 __CONTENT_PARSING__
 
 #   undef return_error

--- a/src/mediafire_sdk/api/templates/api_template.hpp.txt
+++ b/src/mediafire_sdk/api/templates/api_template.hpp.txt
@@ -24,13 +24,26 @@ namespace __CPPSAFE_NAME__ {
 namespace __VERSION__ {
 __ENUMS__
 /**
+ * @class ResponseData
+ * @brief Response data from API request "__API_ACTION_PATH__"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+__DATA_TYPE_CTOR____DATA_TYPE_STRUCTS____DATA_TYPES__};
+
+/**
  * @class Response
  * @brief Response from API request "__API_ACTION_PATH__"
  */
 class Response : public ResponseBase
 {
 public:
-__DATA_TYPE_CTOR____DATA_TYPE_STRUCTS____DATA_TYPES__};
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
 
 class Impl;
 
@@ -46,7 +59,10 @@ __HPP_NAMESPACED_ENUMS____HPP_CTORS__
 __HPP_OPTIONAL_SETTERS__    // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/types.hpp
+++ b/src/mediafire_sdk/api/types.hpp
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "boost/optional/optional.hpp"
+
 namespace mf
 {
 namespace api
@@ -35,7 +37,7 @@ enum class RequestStarted
 struct SessionTokenData
 {
     std::string session_token;
-    std::string pkey;
+    boost::optional<std::string> pkey;
     std::string time;
     int secret_key;
 };

--- a/src/mediafire_sdk/api/unit_tests/ut_api.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_api.cpp
@@ -29,8 +29,8 @@
 #include "boost/asio.hpp"
 #include "boost/asio/ssl.hpp"
 #ifdef BOOST_ASIO_SEPARATE_COMPILATION
-#  include "boost/asio/impl/src.hpp"  // Define once in program
-#  include "boost/asio/ssl/impl/src.hpp"  // Define once in program
+#include "boost/asio/impl/src.hpp"      // Define once in program
+#include "boost/asio/ssl/impl/src.hpp"  // Define once in program
 #endif
 
 #define BOOST_TEST_MODULE Requester
@@ -39,8 +39,8 @@
 namespace asio = boost::asio;
 namespace api = mf::api;
 
-#if ! defined(TEST_USER_1_USERNAME) || ! defined(TEST_USER_1_PASSWORD)
-# error "TEST_USER defines not set."
+#if !defined(TEST_USER_1_USERNAME) || !defined(TEST_USER_1_PASSWORD)
+#error "TEST_USER defines not set."
 #endif
 
 const std::string username = TEST_USER_1_USERNAME;
@@ -52,82 +52,61 @@ BOOST_AUTO_TEST_CASE(SessionTokenSuccess)
         "388e95260b26c834f0436929357e3ba5b9b0468f0d8a1a2de3155688b3aa1f8eb55342"
         "49abbf003e3839e9035f2275eb10";
 
-    boost::property_tree::wptree pt =
-        api::ut::MakeBaseApiContent("user/get_session_token");
-    pt.put(L"response.session_token", mf::utils::bytes_to_wide(session_token) );
-    pt.put(L"response.secret_key", L"1955614760" );
-    pt.put(L"response.time", L"1396873639.6026" );
-    pt.put(L"response.pkey", L"09b3b02524" );
-    pt.put(L"response.ekey", L"9642583c5f69d94c45eff31123a5bc01" );
-    pt.put(L"response.current_api_version", L"1.1" );
+    boost::property_tree::wptree pt
+            = api::ut::MakeBaseApiContent("user/get_session_token");
+    pt.put(L"response.session_token", mf::utils::bytes_to_wide(session_token));
+    pt.put(L"response.secret_key", L"1955614760");
+    pt.put(L"response.time", L"1396873639.6026");
+    pt.put(L"response.pkey", L"09b3b02524");
+    pt.put(L"response.ekey", L"9642583c5f69d94c45eff31123a5bc01");
+    pt.put(L"response.current_api_version", L"1.1");
 
     std::string request_header_regex = "GET.*get_session_token.*\r\n\r\n";
 
     typedef api::ut::ApiExpectServer<api::user::get_session_token::Request>
-        Wrapper;
-    Wrapper wrapper(
-            pt,
-            request_header_regex,
-            200,
-            "OK"
-        );
+            Wrapper;
+    Wrapper wrapper(pt, request_header_regex, 200, "OK");
 
     api::user::get_session_token::Request request(
-        api::credentials::Email{ username, password });
+            api::credentials::Email{username, password});
 
-    wrapper.Run(
-            request,
-            boost::bind(
-                &Wrapper::Callback, &wrapper,
-                _1 )
-        );
+    wrapper.Run(request, boost::bind(&Wrapper::Callback, &wrapper, _1));
 
-    auto & data = wrapper.Data();
+    auto & response = wrapper.Data();
 
-    BOOST_CHECK( ! data.error_code );
+    BOOST_CHECK(!response.error_code);
 
-    if (data.error_code)
+    if (response.error_code)
     {
-        std::cout << "Error code: " << data.error_code << std::endl;
+        std::cout << "Error code: " << response.error_code << std::endl;
 
-        if (data.error_string)
-            std::cout << "Error code: " << data.error_string << std::endl;
+        if (response.error_string)
+            std::cout << "Error code: " << response.error_string << std::endl;
     }
+    else
+    {
+        const auto & response_data = *response.response_data;
 
-    BOOST_CHECK_EQUAL(
-            data.session_token,
-            session_token );
+        BOOST_CHECK_EQUAL(response_data.session_token, session_token);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(SessionTokenFailure)
 {
     boost::property_tree::wptree pt = api::ut::MakeErrorApiContent(
-            "user/get_session_token",
-            "The Credentials you entered are invalid",
-            107
-            );
+            "user/get_session_token", "The Credentials you entered are invalid",
+            107);
 
     std::string request_header_regex = "GET.*get_session_token.*\r\n\r\n";
 
     typedef api::ut::ApiExpectServer<api::user::get_session_token::Request>
-        Wrapper;
-    Wrapper wrapper(
-            pt,
-            request_header_regex,
-            403,
-            "Forbidden"
-        );
+            Wrapper;
+    Wrapper wrapper(pt, request_header_regex, 403, "Forbidden");
 
     api::user::get_session_token::Request request(
-        api::credentials::Email{ username, password });
+            api::credentials::Email{username, password});
 
-    wrapper.Run(
-            request,
-            boost::bind(
-                &Wrapper::Callback, &wrapper,
-                _1 )
-        );
+    wrapper.Run(request, boost::bind(&Wrapper::Callback, &wrapper, _1));
 
-    BOOST_CHECK( wrapper.Data().error_code );
+    BOOST_CHECK(wrapper.Data().error_code);
 }
-

--- a/src/mediafire_sdk/api/unit_tests/ut_clone_cloud_tree.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_clone_cloud_tree.cpp
@@ -43,9 +43,9 @@ BOOST_AUTO_TEST_CASE(UTGetContentFiles)
     stm.SetLoginCredentials(api::credentials::Email{username, password});
 
     using RequestType = mf::api::folder::get_content::Request;
-    using ResponseType = RequestType::ResponseType;
-    using ResponseTypeFiles = std::vector<ResponseType::File>;
-    using ResponseTypeFolders = std::vector<ResponseType::Folder>;
+    using ResponseDataType = RequestType::ResponseDataType;
+    using ResponseTypeFiles = std::vector<ResponseDataType::File>;
+    using ResponseTypeFolders = std::vector<ResponseDataType::Folder>;
 
     using GetFolderContentType = mf::api::GetFolderContents<RequestType>;
 
@@ -64,8 +64,7 @@ BOOST_AUTO_TEST_CASE(UTGetContentFiles)
     };
 
     auto get_folder_contents = GetFolderContentType::Create(
-            &stm,
-            root_folderkey,
+            &stm, root_folderkey,
             GetFolderContentType::FilesOrFoldersOrBoth::Files,
             std::move(HandleGetFolderContents));
     get_folder_contents->Start();
@@ -84,9 +83,9 @@ BOOST_AUTO_TEST_CASE(UTGetContentFolders)
     stm.SetLoginCredentials(api::credentials::Email{username, password});
 
     using RequestType = mf::api::folder::get_content::Request;
-    using ResponseType = RequestType::ResponseType;
-    using ResponseTypeFiles = std::vector<ResponseType::File>;
-    using ResponseTypeFolders = std::vector<ResponseType::Folder>;
+    using ResponseDataType = RequestType::ResponseDataType;
+    using ResponseTypeFiles = std::vector<ResponseDataType::File>;
+    using ResponseTypeFolders = std::vector<ResponseDataType::Folder>;
 
     using GetFolderContentType = mf::api::GetFolderContents<RequestType>;
 
@@ -105,8 +104,7 @@ BOOST_AUTO_TEST_CASE(UTGetContentFolders)
     };
 
     auto get_folder_contents = GetFolderContentType::Create(
-            &stm,
-            root_folderkey,
+            &stm, root_folderkey,
             GetFolderContentType::FilesOrFoldersOrBoth::Folders,
             std::move(HandleGetFolderContents));
     get_folder_contents->Start();
@@ -125,9 +123,9 @@ BOOST_AUTO_TEST_CASE(UTGetContentFilesAndFolders)
     stm.SetLoginCredentials(api::credentials::Email{username, password});
 
     using RequestType = mf::api::folder::get_content::Request;
-    using ResponseType = RequestType::ResponseType;
-    using ResponseTypeFiles = std::vector<ResponseType::File>;
-    using ResponseTypeFolders = std::vector<ResponseType::Folder>;
+    using ResponseDataType = RequestType::ResponseDataType;
+    using ResponseTypeFiles = std::vector<ResponseDataType::File>;
+    using ResponseTypeFolders = std::vector<ResponseDataType::Folder>;
 
     using GetFolderContentType = mf::api::GetFolderContents<RequestType>;
 
@@ -144,8 +142,7 @@ BOOST_AUTO_TEST_CASE(UTGetContentFilesAndFolders)
     };
 
     auto get_folder_contents = GetFolderContentType::Create(
-            &stm,
-            root_folderkey,
+            &stm, root_folderkey,
             GetFolderContentType::FilesOrFoldersOrBoth::Both,
             std::move(HandleGetFolderContents));
     get_folder_contents->Start();
@@ -184,8 +181,9 @@ BOOST_AUTO_TEST_CASE(UTCloneCloudTree)
     // io_service.
     auto work_manager = mf::api::WorkManager::Create(&io_service);
 
-    auto clone_cloud_tree = CloneCloudTreeType::Create(
-            &stm, root_folderkey, work_manager, std::move(HandleCloneCloudTree));
+    auto clone_cloud_tree
+            = CloneCloudTreeType::Create(&stm, root_folderkey, work_manager,
+                                         std::move(HandleCloneCloudTree));
     clone_cloud_tree->Start();
 
     io_service.run();

--- a/src/mediafire_sdk/api/unit_tests/ut_get_info_file.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_get_info_file.cpp
@@ -41,25 +41,29 @@ BOOST_AUTO_TEST_CASE(UTGetInfoFile)
     using RequestType = GetInfoFileType::RequestType;
     using ResponseType = GetInfoFileType::ResponseType;
 
-    GetInfoFileType::CallbackType HandleGetInfoFile =
-            [this, &io_service](const ResponseType & response,
-                                const std::vector<GetInfoFileType::ErrorType> &
-                                        errors)
+    GetInfoFileType::CallbackType HandleGetInfoFile = [this, &io_service](
+            const ResponseType & response,
+            const std::vector<GetInfoFileType::ErrorType> & errors)
     {
         if (!errors.empty())
         {
             BOOST_FAIL("HandleGetInfoFile reported errors!");
         }
+        else if (!response.response_data)
+        {
+            BOOST_FAIL("HandleGetInfoFile missing response_data!");
+        }
         else
         {
-            std::cout << response.quickkey << std::endl;
+            std::cout << response.response_data->quickkey << std::endl;
         }
 
         io_service.stop();
     };
 
-    auto get_folder_info
-            = GetInfoFileType::Create(&stm, "", std::move(HandleGetInfoFile)); // TODO: Add a default quickkey
+    auto get_folder_info = GetInfoFileType::Create(
+            &stm, "",
+            std::move(HandleGetInfoFile));  // TODO: Add a default quickkey
 
     get_folder_info->Start();
 

--- a/src/mediafire_sdk/api/unit_tests/ut_get_info_folder.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_get_info_folder.cpp
@@ -43,12 +43,15 @@ BOOST_AUTO_TEST_CASE(UTGetInfoFolder)
 
     using GetInfoFolderErrorType = typename GetInfoFolderType::ErrorType;
 
-    GetInfoFolderType::CallbackType HandleGetInfoFolder = [this, &io_service](
-            const ResponseType & response,
-            const std::vector<GetInfoFolderErrorType> &
-                    errors)  // TODO: Add errors
+    GetInfoFolderType::CallbackType HandleGetInfoFolder =
+            [this, &io_service](const ResponseType & response,
+                                const std::vector<GetInfoFolderErrorType> &
+                                        errors)  // TODO: Add errors
     {
-        std::cout << response.folderkey << std::endl;
+        if (response.response_data)
+            std::cout << response.response_data->folderkey << std::endl;
+        else
+            std::cout << "No folderkey" << std::endl;
 
         io_service.stop();
     };

--- a/src/mediafire_sdk/api/unit_tests/ut_live.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live.cpp
@@ -124,24 +124,29 @@ void Fixture::WaitForAnyAsyncOperationsToComplete()
     Call(api::device::get_status::Request(),
          [&](const api::device::get_status::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  // Ignore error, try again
                  WaitForAnyAsyncOperationsToComplete();
              }
-             else if (response.async_jobs_in_progress
-                      == api::device::get_status::AsyncJobs::Stopped)
-             {
-                 Stop();
-             }
              else
              {
-                 if (!async_wait_logged_)
+                 const auto & data = *response.response_data;
+
+                 if (data.async_jobs_in_progress
+                     == api::device::get_status::AsyncJobs::Stopped)
                  {
-                     async_wait_logged_ = true;
-                     Log("Waiting for asynchronous operation to complete.");
+                     Stop();
                  }
-                 WaitForAnyAsyncOperationsToComplete();
+                 else
+                 {
+                     if (!async_wait_logged_)
+                     {
+                         async_wait_logged_ = true;
+                         Log("Waiting for asynchronous operation to complete.");
+                     }
+                     WaitForAnyAsyncOperationsToComplete();
+                 }
              }
          });
 }

--- a/src/mediafire_sdk/api/unit_tests/ut_live_billing.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live_billing.cpp
@@ -7,7 +7,7 @@
 #include "ut_live.hpp"
 
 #ifndef OUTPUT_DEBUG
-#  define OUTPUT_DEBUG
+#define OUTPUT_DEBUG
 #endif
 
 #include "mediafire_sdk/api/billing/get_products.hpp"
@@ -23,61 +23,62 @@
 
 namespace api = mf::api;
 
-BOOST_FIXTURE_TEST_SUITE( s, ut::Fixture )
+BOOST_FIXTURE_TEST_SUITE(s, ut::Fixture)
 
 BOOST_AUTO_TEST_CASE(GetBillingProducts)
 {
     api::billing::get_products::Request request;
     request.SetActive(api::billing::get_products::Activity::Active);
 
-    Call(
-        request,
-        [&](const api::billing::get_products::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
+    Call(request, [&](const api::billing::get_products::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
 
-                BOOST_CHECK( ! response.products.empty() );
+                 Success();
 
-                for ( const api::billing::get_products::Response::Product & it
-                    : response.products )
-                {
-                    BOOST_CHECK( ! it.description.empty() );
-                }
-            }
-        });
+                 BOOST_CHECK(!data.products.empty());
+
+                 for (const api::billing::get_products::ResponseData::Product &
+                              it : data.products)
+                 {
+                     BOOST_CHECK(!it.description.empty());
+                 }
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(GetBillingPlans)
 {
-    Call(
-        api::billing::get_plans::Request(),
-        [&](const api::billing::get_plans::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
+    Call(api::billing::get_plans::Request(),
+         [&](const api::billing::get_plans::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
 
-                BOOST_CHECK( ! response.plans.empty() );
+                 Success();
 
-                for ( const api::billing::get_plans::Response::Plan & it
-                    : response.plans )
-                {
-                    BOOST_CHECK( ! it.description.empty() );
-                }
-            }
-        });
+                 BOOST_CHECK(!data.plans.empty());
+
+                 for (const api::billing::get_plans::ResponseData::Plan & it :
+                      data.plans)
+                 {
+                     BOOST_CHECK(!it.description.empty());
+                 }
+             }
+         });
 
     StartWithDefaultTimeout();
 }

--- a/src/mediafire_sdk/api/unit_tests/ut_live_device.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live_device.cpp
@@ -7,7 +7,7 @@
 #include "ut_live.hpp"
 
 #ifndef OUTPUT_DEBUG
-#  define OUTPUT_DEBUG
+#define OUTPUT_DEBUG
 #endif
 
 #include "mediafire_sdk/api/device/get_changes.hpp"
@@ -23,32 +23,33 @@
 
 namespace api = mf::api;
 
-namespace globals {
+namespace globals
+{
 using namespace ut::globals;
 uint32_t known_revision = 0;
 }  // namespace globals
 
-BOOST_FIXTURE_TEST_SUITE( s, ut::Fixture )
+BOOST_FIXTURE_TEST_SUITE(s, ut::Fixture)
 
 /**
  * Get the device revision for the next text
  */
 BOOST_AUTO_TEST_CASE(DeviceGetStatus)
 {
-    Call(
-        api::device::get_status::Request(),
-        [&](const api::device::get_status::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                globals::known_revision = response.device_revision;
-                Success();
-            }
-        });
+    Call(api::device::get_status::Request(),
+         [&](const api::device::get_status::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 globals::known_revision = data.device_revision;
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
@@ -59,19 +60,18 @@ BOOST_AUTO_TEST_CASE(DeviceGetChanges)
     uint32_t revision = globals::known_revision;
     revision -= revision % 500;
 
-    Call(
-        api::device::get_changes::Request(revision),
-        [&](const api::device::get_changes::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::device::get_changes::Request(revision),
+         [&](const api::device::get_changes::Response & response)
+         {
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }

--- a/src/mediafire_sdk/api/unit_tests/ut_live_folder.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live_folder.cpp
@@ -7,7 +7,7 @@
 #include "ut_live.hpp"
 
 #ifndef OUTPUT_DEBUG
-#  define OUTPUT_DEBUG
+#define OUTPUT_DEBUG
 #endif
 
 #include "mediafire_sdk/api/folder/copy.hpp"
@@ -28,78 +28,75 @@
 
 namespace api = mf::api;
 
-BOOST_FIXTURE_TEST_SUITE( s, ut::Fixture )
+BOOST_FIXTURE_TEST_SUITE(s, ut::Fixture)
 
 BOOST_AUTO_TEST_CASE(FolderGetContentLive)
 {
     api::folder::get_content::Request get_content(
-        "myfiles",  // folder_key
-        0,  // chunk
-        api::folder::get_content::ContentType::Files  // content_type
-    );
+            "myfiles",                                    // folder_key
+            0,                                            // chunk
+            api::folder::get_content::ContentType::Files  // content_type
+            );
 
-    Call(
-        get_content,
-        [&](const api::folder::get_content::Response & response)
-        {
-            Stop();
+    Call(get_content, [&](const api::folder::get_content::Response & response)
+         {
+             Stop();
 
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(FolderGetInfoMyFilesBlank)
 {
-    Call(
-        api::folder::get_info::Request(""),
-        [&](const api::folder::get_info::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
+    Call(api::folder::get_info::Request(""),
+         [&](const api::folder::get_info::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
 
-                BOOST_CHECK( ! response.folderkey.empty() );
-            }
-        });
+                 Success();
+
+                 BOOST_CHECK(!data.folderkey.empty());
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(FolderGetInfoMyFilesExplicit)
 {
-    Call(
-        api::folder::get_info::Request("myfiles"),
-        [&](const api::folder::get_info::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
+    Call(api::folder::get_info::Request("myfiles"),
+         [&](const api::folder::get_info::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
 
-                BOOST_CHECK( ! response.folderkey.empty() );
-            }
-        });
+                 Success();
+
+                 BOOST_CHECK(!data.folderkey.empty());
+             }
+         });
 
     StartWithDefaultTimeout();
 }
-
-
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mediafire_sdk/api/unit_tests/ut_live_general.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live_general.cpp
@@ -224,17 +224,19 @@ BOOST_AUTO_TEST_CASE(CreateFolder)
     Call(api::folder::create::Request(globals::test_folder_name),
          [&](const api::folder::create::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::test_folderkey = response.folderkey;
+                 globals::test_folderkey = response_data.folderkey;
 
-                 BOOST_CHECK(!response.folderkey.empty());
+                 BOOST_CHECK(!response_data.folderkey.empty());
              }
          });
 
@@ -250,17 +252,19 @@ BOOST_AUTO_TEST_CASE(CreateFolder2)
     Call(api::folder::create::Request(globals::test_folder_name2),
          [&](const api::folder::create::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::test_folderkey2 = response.folderkey;
+                 globals::test_folderkey2 = response_data.folderkey;
 
-                 BOOST_CHECK(!response.folderkey.empty());
+                 BOOST_CHECK(!response_data.folderkey.empty());
              }
          });
 
@@ -272,15 +276,17 @@ BOOST_AUTO_TEST_CASE(FolderGetInfo)
     Call(api::folder::get_info::Request(globals::test_folderkey),
          [&](const api::folder::get_info::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 BOOST_CHECK(!response.folderkey.empty());
+                 BOOST_CHECK(!response_data.folderkey.empty());
              }
          });
 
@@ -301,13 +307,15 @@ BOOST_AUTO_TEST_CASE(CreateFile)
 
     Call(request, [&](const api::file::create::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
-                 if (!response.links.normal_download)
+                 const auto & response_data = *response.response_data;
+
+                 if (!response_data.links.normal_download)
                  {
                      Fail("Newly created file should have normal download "
                           "field for downloading file.");
@@ -317,10 +325,10 @@ BOOST_AUTO_TEST_CASE(CreateFile)
                      Success();
                  }
 
-                 globals::test_quickkey = response.quickkey;
+                 globals::test_quickkey = response_data.quickkey;
 
-                 BOOST_CHECK(!response.quickkey.empty());
-                 BOOST_CHECK(response.created_datetime
+                 BOOST_CHECK(!response_data.quickkey.empty());
+                 BOOST_CHECK(response_data.created_datetime
                              != boost::date_time::not_a_date_time);
              }
          });
@@ -336,19 +344,21 @@ BOOST_AUTO_TEST_CASE(CopyFile1)
 
     Call(request, [&](const api::file::copy::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::test_quickkey2 = response.quickkey;
+                 globals::test_quickkey2 = response_data.quickkey;
 
-                 Debug(response.quickkey);
+                 Debug(response_data.quickkey);
 
-                 BOOST_CHECK(!response.quickkey.empty());
+                 BOOST_CHECK(!response_data.quickkey.empty());
              }
          });
 
@@ -427,14 +437,16 @@ BOOST_AUTO_TEST_CASE(VerifyOneVersionExists)
 
     Call(request, [&](const api::file::get_versions::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  // There should be at least two versions.
-                 if (response.file_versions.size() != 1)
+                 if (response_data.file_versions.size() != 1)
                  {
                      Fail("There should be only one file version after "
                           "replacement upload.");
@@ -442,10 +454,10 @@ BOOST_AUTO_TEST_CASE(VerifyOneVersionExists)
                  else
                  {
                      Log("Got versions:");
-                     for (auto & version : response.file_versions)
+                     for (auto & version : response_data.file_versions)
                          Log(version.revision);
 
-                     if (response.file_versions[0].revision
+                     if (response_data.file_versions[0].revision
                          != globals::upload::upload_revision_1)
                      {
                          Fail("The revision received from the uploader does "
@@ -476,19 +488,21 @@ BOOST_AUTO_TEST_CASE(CopyFile2)
 
     Call(request, [&](const api::file::copy::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::test_quickkey2 = response.quickkey;
+                 globals::test_quickkey2 = response_data.quickkey;
 
-                 Debug(response.quickkey);
+                 Debug(response_data.quickkey);
 
-                 BOOST_CHECK(!response.quickkey.empty());
+                 BOOST_CHECK(!response_data.quickkey.empty());
              }
          });
 
@@ -617,14 +631,16 @@ BOOST_AUTO_TEST_CASE(VerifyNewVersionExists)
                    const bool timed_out = now > timeout;
                    bool had_success = false;
 
-                   if (response.error_code)
+                   if (!response.response_data)
                    {
                        Fail(response);
                    }
                    else
                    {
+                       const auto & response_data = *response.response_data;
+
                        // There should be at least two versions.
-                       if (response.file_versions.size() < 2)
+                       if (response_data.file_versions.size() < 2)
                        {
                            if (timed_out)
                            {
@@ -641,7 +657,8 @@ BOOST_AUTO_TEST_CASE(VerifyNewVersionExists)
                            bool original_revision_found = false;
                            bool new_revision_found = false;
 
-                           for (auto & version_info : response.file_versions)
+                           for (auto & version_info :
+                                response_data.file_versions)
                            {
                                if (version_info.revision
                                    == globals::upload::upload_revision_1)
@@ -717,7 +734,7 @@ BOOST_AUTO_TEST_CASE(RestoreFile)
 
     Call(request, [&](const api::file::restore::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
@@ -756,36 +773,43 @@ BOOST_AUTO_TEST_CASE(VerifyRestoreFile)
                  // 3. Revision is incremented
                  //    - Revisions must increment, otherwise device/get_changes
                  //      will not work properly.
-                 if (response.error_code)
+                 if (!response.response_data)
                  {
                      Fail(response);
                  }
-                 else if (response.hash != globals::upload::hash_1)
-                 {
-                     Log("First hash:", globals::upload::hash_1);
-                     Log("Second hash:", globals::upload::hash_2);
-                     Log("Hash after restoration:", response.hash);
-                     Log("Revisions. 1:", globals::upload::upload_revision_1,
-                         "2:", globals::upload::upload_revision_2, "Current:",
-                         response.revision);
-
-                     Fail("Hash on restored file incorrect!");
-                 }
-                 else if (response.revision
-                          <= globals::upload::upload_revision_2)
-                 {
-                     Log("First hash:", globals::upload::hash_1);
-                     Log("Second hash:", globals::upload::hash_2);
-                     Log("Hash after restoration:", response.hash);
-                     Log("Revisions. 1:", globals::upload::upload_revision_1,
-                         "2:", globals::upload::upload_revision_2, "Current:",
-                         response.revision);
-
-                     Fail("Revision on file not incremented!");
-                 }
                  else
                  {
-                     Success();
+                     const auto & response_data = *response.response_data;
+
+                     if (response_data.hash != globals::upload::hash_1)
+                     {
+                         Log("First hash:", globals::upload::hash_1);
+                         Log("Second hash:", globals::upload::hash_2);
+                         Log("Hash after restoration:", response_data.hash);
+                         Log("Revisions. 1:",
+                             globals::upload::upload_revision_1, "2:",
+                             globals::upload::upload_revision_2, "Current:",
+                             response_data.revision);
+
+                         Fail("Hash on restored file incorrect!");
+                     }
+                     else if (response_data.revision
+                              <= globals::upload::upload_revision_2)
+                     {
+                         Log("First hash:", globals::upload::hash_1);
+                         Log("Second hash:", globals::upload::hash_2);
+                         Log("Hash after restoration:", response_data.hash);
+                         Log("Revisions. 1:",
+                             globals::upload::upload_revision_1, "2:",
+                             globals::upload::upload_revision_2, "Current:",
+                             response_data.revision);
+
+                         Fail("Revision on file not incremented!");
+                     }
+                     else
+                     {
+                         Success();
+                     }
                  }
              });
 
@@ -810,14 +834,16 @@ BOOST_AUTO_TEST_CASE(GetFileVersions)
 
     Call(request, [&](const api::file::get_versions::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  // There should be at least one version.
-                 if (response.file_versions.size() > 0)
+                 if (response_data.file_versions.size() > 0)
                  {
                      Success();
                  }
@@ -843,14 +869,16 @@ BOOST_AUTO_TEST_CASE(RecentlyModified)
 
     Call(request, [&](const api::file::recently_modified::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  // There should be at least one version.
-                 if (response.quickkeys.size() > 0)
+                 if (response_data.quickkeys.size() > 0)
                  {
                      Success();
                  }
@@ -878,15 +906,17 @@ BOOST_AUTO_TEST_CASE(OneTimeKey)
 
     Call(request, [&](const api::file::one_time_key::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
-                 globals::one_time_key::download_token = response.token;
+                 const auto & response_data = *response.response_data;
+
+                 globals::one_time_key::download_token = response_data.token;
                  // There should be at least one version.
-                 if (response.download_link)
+                 if (response_data.download_link)
                  {
                      Success();
                  }
@@ -910,7 +940,7 @@ BOOST_AUTO_TEST_CASE(ConfigureOneTimeKey)
     Call(request,
          [&](const api::file::configure_one_time_key::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
@@ -928,15 +958,17 @@ BOOST_AUTO_TEST_CASE(FileGetInfo)
     Call(api::file::get_info::Request(globals::test_quickkey2),
          [&](const api::file::get_info::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
 #if 0  // Re-enable when #27247 is complete and we have upgraded to v1.3 of file/get_info
 
-                if (!response.links.normal_download)
+                if (!response_data.links.normal_download)
                 {
                     Fail("All files should return normal download field for "
                          "downloading file.");
@@ -947,11 +979,11 @@ BOOST_AUTO_TEST_CASE(FileGetInfo)
                      Success();
                  }
 
-                 globals::test_file_name2 = response.filename;
+                 globals::test_file_name2 = response_data.filename;
 
                  Debug(globals::test_file_name2);
 
-                 BOOST_CHECK(!response.quickkey.empty());
+                 BOOST_CHECK(!response_data.quickkey.empty());
              }
          });
 
@@ -965,7 +997,7 @@ BOOST_AUTO_TEST_CASE(FileMove)
 
     Call(request, [&](const api::file::move::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
                  Fail(response);
              else
                  Success();
@@ -984,7 +1016,7 @@ BOOST_AUTO_TEST_CASE(FileRename)
 
     Call(request, [&](const api::file::update::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
@@ -1006,7 +1038,7 @@ BOOST_AUTO_TEST_CASE(FileMakePrivate)
 
     Call(request, [&](const api::file::update::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
                  Fail(response);
              else
                  Success();
@@ -1020,15 +1052,17 @@ BOOST_AUTO_TEST_CASE(FileIsPrivate)
     Call(api::file::get_info::Request(globals::test_quickkey2),
          [&](const api::file::get_info::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 BOOST_CHECK(response.privacy
+                 BOOST_CHECK(response_data.privacy
                              == api::file::get_info::Privacy::Private);
              }
          });
@@ -1047,7 +1081,7 @@ BOOST_AUTO_TEST_CASE(DeleteFile)
     Call(api::file::file_delete::Request(globals::test_quickkey2),
          [&](const api::file::file_delete::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
                  Fail(response);
              else
                  Success();
@@ -1062,21 +1096,26 @@ BOOST_AUTO_TEST_CASE(FileGetLinks)
     Call(api::file::get_links::Request(quickkeys),
          [&](const api::file::get_links::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
-             else if (response.links.empty())
-             {
-                 Fail("No links were provided.");
-             }
-             else if (!response.links[0].one_time_download)
-             {
-                 Fail("get_links should have provided a one time link.");
-             }
              else
              {
-                 Success();
+                 const auto & response_data = *response.response_data;
+
+                 if (response_data.links.empty())
+                 {
+                     Fail("No links were provided.");
+                 }
+                 else if (!response_data.links[0].one_time_download)
+                 {
+                     Fail("get_links should have provided a one time link.");
+                 }
+                 else
+                 {
+                     Success();
+                 }
              }
          });
 
@@ -1091,16 +1130,18 @@ BOOST_AUTO_TEST_CASE(PreConfirmCopyMove)
 
     Call(request, [&](const api::folder::get_info::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::copy_move::files = response.file_count;
-                 globals::copy_move::folders = response.folder_count;
+                 globals::copy_move::files = response_data.file_count;
+                 globals::copy_move::folders = response_data.folder_count;
              }
          });
 
@@ -1113,15 +1154,17 @@ BOOST_AUTO_TEST_CASE(CopyFolder)
                                     globals::test_folderkey2),
          [&](const api::folder::copy::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::test_folderkey3 = response.folderkey;
+                 globals::test_folderkey3 = response_data.folderkey;
                  globals::test_folder_name3 = globals::test_folder_name;
              }
          });
@@ -1135,7 +1178,7 @@ BOOST_AUTO_TEST_CASE(MoveFolder)
                                     globals::test_folderkey),
          [&](const api::folder::move::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
                  Fail(response);
              else
                  Success();
@@ -1152,14 +1195,17 @@ BOOST_AUTO_TEST_CASE(RenameFolder)
 
     Call(request, [&](const api::folder::update::Response & response)
          {
-             if (response.error_code || !response.device_revision)
+             if (!response.response_data
+                 || !response.response_data->device_revision)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
-                 globals::known_revision = *response.device_revision;
+                 globals::known_revision = *response_data.device_revision;
              }
          });
 
@@ -1174,21 +1220,23 @@ BOOST_AUTO_TEST_CASE(ConfirmCopyMove)
 
     Call(request, [&](const api::folder::get_info::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
                  // std::cout << "files: " << response.total_files << std::endl;
                  // std::cout << "folders: " << response.total_folders <<
                  // std::endl;
 
-                 BOOST_CHECK_EQUAL(response.file_count,
+                 BOOST_CHECK_EQUAL(response_data.file_count,
                                    globals::copy_move::files);
-                 BOOST_CHECK_EQUAL(response.folder_count,
+                 BOOST_CHECK_EQUAL(response_data.folder_count,
                                    globals::copy_move::folders + 1);
              }
          });
@@ -1202,7 +1250,7 @@ BOOST_AUTO_TEST_CASE(PurgeFile)
     Call(api::file::purge::Request(quickkeys),
          [&](const api::file::purge::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
                  Fail(response);
              else
                  Success();
@@ -1275,7 +1323,7 @@ BOOST_AUTO_TEST_CASE(UpdateFile)
          {
              Debug(response.debug);
 
-             if (response.error_code)
+             if (!response.response_data)
                  Fail(response);
              else
                  Success();
@@ -1299,7 +1347,7 @@ BOOST_AUTO_TEST_CASE(FolderDelete2)
             ),
         [&](const api::folder::folder_delete::Response & response)
         {
-            if ( response.error_code )
+            if (!response.response_data)
             {
                 Fail(response);
             }
@@ -1328,20 +1376,24 @@ BOOST_AUTO_TEST_CASE(DeviceGetChanges)
     Call(api::device::get_changes::Request(revision),
          [&](const api::device::get_changes::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::has_updated_files = !response.updated_files.empty();
+                 globals::has_updated_files
+                         = !response_data.updated_files.empty();
                  globals::has_updated_folders
-                         = !response.updated_folders.empty();
-                 globals::has_deleted_files = !response.deleted_files.empty();
+                         = !response_data.updated_folders.empty();
+                 globals::has_deleted_files
+                         = !response_data.deleted_files.empty();
                  globals::has_deleted_folders
-                         = !response.deleted_folders.empty();
+                         = !response_data.deleted_folders.empty();
              }
          });
 
@@ -1363,20 +1415,24 @@ BOOST_AUTO_TEST_CASE(DeviceGetChanges2)
     Call(api::device::get_changes::Request(revision),
          [&](const api::device::get_changes::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::has_updated_files |= !response.updated_files.empty();
+                 globals::has_updated_files
+                         |= !response_data.updated_files.empty();
                  globals::has_updated_folders
-                         |= !response.updated_folders.empty();
-                 globals::has_deleted_files |= !response.deleted_files.empty();
+                         |= !response_data.updated_folders.empty();
+                 globals::has_deleted_files
+                         |= !response_data.deleted_files.empty();
                  globals::has_deleted_folders
-                         |= !response.deleted_folders.empty();
+                         |= !response_data.deleted_folders.empty();
 
                  // Files were created.
                  BOOST_CHECK(globals::has_updated_files);
@@ -1406,17 +1462,19 @@ BOOST_AUTO_TEST_CASE(CreateFolderUser2)
     Call(api::folder::create::Request(globals::foreign_folder_name),
          [&](const api::folder::create::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & response_data = *response.response_data;
+
                  Success();
 
-                 globals::foreign_folderkey = response.folderkey;
+                 globals::foreign_folderkey = response_data.folderkey;
 
-                 BOOST_CHECK(!response.folderkey.empty());
+                 BOOST_CHECK(!response_data.folderkey.empty());
              }
          });
 
@@ -1428,14 +1486,10 @@ BOOST_AUTO_TEST_CASE(DeviceGetStatusPreDelete1)
     Call(api::device::get_status::Request(),
          [&](const api::device::get_status::Response & response)
          {
-             if (response.error_code)
-             {
+             if (!response.response_data)
                  Fail(response);
-             }
              else
-             {
                  Success();
-             }
          });
 
     StartWithDefaultTimeout();
@@ -1472,14 +1526,10 @@ BOOST_AUTO_TEST_CASE(FolderDelete1)
         Call(api::folder::folder_delete::Request(keys),
              [&](const api::folder::folder_delete::Response & response)
              {
-                 if (response.error_code)
-                 {
+                 if (!response.response_data)
                      Fail(response);
-                 }
                  else
-                 {
                      Success();
-                 }
              });
 
         StartWithDefaultTimeout();
@@ -1491,14 +1541,10 @@ BOOST_AUTO_TEST_CASE(DeviceGetStatusPreDelete2)
     Call(api::device::get_status::Request(),
          [&](const api::device::get_status::Response & response)
          {
-             if (response.error_code)
-             {
+             if (!response.response_data)
                  Fail(response);
-             }
              else
-             {
                  Success();
-             }
          });
 
     StartWithDefaultTimeout();
@@ -1535,7 +1581,7 @@ BOOST_AUTO_TEST_CASE(FolderDelete2)
         Call(api::folder::folder_delete::Request(keys),
              [&](const api::folder::folder_delete::Response & response)
              {
-                 if (response.error_code)
+                 if (!response.response_data)
                      Fail(response);
                  else
                      Success();
@@ -1550,14 +1596,10 @@ BOOST_AUTO_TEST_CASE(DeviceGetStatusPostDelete)
     Call(api::device::get_status::Request(),
          [&](const api::device::get_status::Response & response)
          {
-             if (response.error_code)
-             {
+             if (!response.response_data)
                  Fail(response);
-             }
              else
-             {
                  Success();
-             }
          });
 
     StartWithDefaultTimeout();
@@ -1586,7 +1628,7 @@ BOOST_AUTO_TEST_CASE(SpamTest)
                  ss << "SpamTest: Count: " << count;
                  Debug(ss.str());
 
-                 if (response.error_code)
+                 if (!response.response_data)
                  {
                      ++times_failed;
                      std::ostringstream error_ss;

--- a/src/mediafire_sdk/api/unit_tests/ut_live_system.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live_system.cpp
@@ -7,7 +7,7 @@
 #include "ut_live.hpp"
 
 #ifndef OUTPUT_DEBUG
-#  define OUTPUT_DEBUG
+#define OUTPUT_DEBUG
 #endif
 
 #include "mediafire_sdk/api/system/get_limits.hpp"
@@ -28,156 +28,151 @@
 
 namespace api = mf::api;
 
-BOOST_FIXTURE_TEST_SUITE( s, ut::Fixture )
+BOOST_FIXTURE_TEST_SUITE(s, ut::Fixture)
 
 BOOST_AUTO_TEST_CASE(SystemGetLimits)
 {
-    Call(
-        api::system::get_limits::Request(),
-        [&](const api::system::get_limits::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::system::get_limits::Request(),
+         [&](const api::system::get_limits::Response & response)
+         {
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(SystemGetStatus)
 {
-    Call(
-        api::system::get_status::Request(),
-        [&](const api::system::get_status::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::system::get_status::Request(),
+         [&](const api::system::get_status::Response & response)
+         {
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(SystemGetVersion)
 {
-    Call(
-        api::system::get_version::Request(),
-        [&](const api::system::get_version::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::system::get_version::Request(),
+         [&](const api::system::get_version::Response & response)
+         {
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(SystemGetInfo)
 {
-    Call(
-        api::system::get_info::Request(),
-        [&](const api::system::get_info::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                bool non_empty = false;
-                for (auto & str : response.viewable_extensions)
-                {
-                    if (!str.empty())
-                    non_empty = true;
-                }
-                if (non_empty)
-                {
-                    Success();
-                }
-                else
-                {
-                    std::cout << "Only empty items in viewable_extensions!"
-                        << std::endl;
-                    Fail(response);
-                }
-            }
-        });
+    Call(api::system::get_info::Request(),
+         [&](const api::system::get_info::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+
+                 bool non_empty = false;
+                 for (auto & str : data.viewable_extensions)
+                 {
+                     if (!str.empty())
+                         non_empty = true;
+                 }
+                 if (non_empty)
+                 {
+                     Success();
+                 }
+                 else
+                 {
+                     std::cout << "Only empty items in viewable_extensions!"
+                               << std::endl;
+                     Fail(response);
+                 }
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(SystemGetSupportedMedia)
 {
-    Call(
-        api::system::get_supported_media::Request(),
-        [&](const api::system::get_supported_media::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::system::get_supported_media::Request(),
+         [&](const api::system::get_supported_media::Response & response)
+         {
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(SystemGetEditableMedia)
 {
-    Call(
-        api::system::get_editable_media::Request(),
-        [&](const api::system::get_editable_media::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::system::get_editable_media::Request(),
+         [&](const api::system::get_editable_media::Response & response)
+         {
+             if (response.error_code)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(SystemGetMimeTypes)
 {
-    Call(
-        api::system::get_mime_types::Request(),
-        [&](const api::system::get_mime_types::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else if ( response.mimetypes.empty() )
-            {
-                Fail("Empty mime type list.");
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::system::get_mime_types::Request(),
+         [&](const api::system::get_mime_types::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else if (response.response_data->mimetypes.empty())
+             {
+                 Fail("Empty mime type list.");
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }

--- a/src/mediafire_sdk/api/unit_tests/ut_live_user.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_live_user.cpp
@@ -7,7 +7,7 @@
 #include "ut_live.hpp"
 
 #ifndef OUTPUT_DEBUG
-#  define OUTPUT_DEBUG
+#define OUTPUT_DEBUG
 #endif
 
 #include "mediafire_sdk/api/user/destroy_action_token.hpp"
@@ -32,36 +32,38 @@
 
 namespace api = mf::api;
 
-namespace globals {
+namespace globals
+{
 using namespace ut::globals;
 std::string action_token;
 }  // namespace globals
 
-BOOST_FIXTURE_TEST_SUITE( s, ut::Fixture )
+BOOST_FIXTURE_TEST_SUITE(s, ut::Fixture)
 
 BOOST_AUTO_TEST_CASE(SessionTokenOverSessionMaintainerLive)
 {
     const api::credentials::Email & connection(globals::connection1);
 
-    Call(
-        api::user::get_session_token::Request(globals::connection1),
-        [connection, this](const api::user::get_session_token::Response & response)
-        {
-            Stop();
+    Call(api::user::get_session_token::Request(globals::connection1),
+         [connection, this](
+                 const api::user::get_session_token::Response & response)
+         {
+             Stop();
 
-            if ( response.error_code )
-            {
-                std::ostringstream ss;
-                ss << "User: " << connection.email << std::endl;
-                ss << "Password: " << connection.password << std::endl;
-                ss << "Error: " << response.error_string << std::endl;
-                BOOST_FAIL(ss.str());
-            }
-            else
-            {
-                BOOST_CHECK( ! response.session_token.empty() );
-            }
-        });
+             if (!response.response_data)
+             {
+                 std::ostringstream ss;
+                 ss << "User: " << connection.email << std::endl;
+                 ss << "Password: " << connection.password << std::endl;
+                 ss << "Error: " << response.error_string << std::endl;
+                 BOOST_FAIL(ss.str());
+             }
+             else
+             {
+                 const auto & response_data = *response.response_data;
+                 BOOST_CHECK(!response_data.session_token.empty());
+             }
+         });
 
     StartWithDefaultTimeout();
 }
@@ -73,21 +75,23 @@ BOOST_AUTO_TEST_CASE(UserGetInfo)
     Call(api::user::get_info::Request(),
          [&](const api::user::get_info::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & data = *response.response_data;
+
                  Log("Has facebook:",
-                     response.facebook && response.facebook->linked == Linked::Yes);
+                     data.facebook && data.facebook->linked == Linked::Yes);
                  Log("Has twitter:",
-                     response.twitter && response.twitter->linked == Linked::Yes);
+                     data.twitter && data.twitter->linked == Linked::Yes);
                  Log("Has gmail:",
-                     response.gmail && response.gmail->linked == Linked::Yes);
-                 Log("Email:", response.email);
-                 Log("Display name:", response.display_name);
-                 Log("Ekey:", response.ekey);
+                     data.gmail && data.gmail->linked == Linked::Yes);
+                 Log("Email:", data.email);
+                 Log("Display name:", data.display_name);
+                 Log("Ekey:", data.ekey);
 
                  Success();
              }
@@ -156,13 +160,15 @@ BOOST_AUTO_TEST_CASE(GetAvatar)
     Call(api::user::get_avatar::Request(),
          [&](const api::user::get_avatar::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
-                 Log("Avatar URL:", response.avatar_url);
+                 const auto & data = *response.response_data;
+
+                 Log("Avatar URL:", data.avatar_url);
 
                  Success();
              }
@@ -174,53 +180,55 @@ BOOST_AUTO_TEST_CASE(SessionMaintainerRestartable)
 {
     const api::credentials::Email & connection(globals::connection1);
 
-    Call(
-        api::user::get_session_token::Request(globals::connection1),
-        [connection, this](const api::user::get_session_token::Response & response)
-        {
-            Stop();
+    Call(api::user::get_session_token::Request(globals::connection1),
+         [connection, this](
+                 const api::user::get_session_token::Response & response)
+         {
+             Stop();
 
-            if ( response.error_code )
-            {
-                std::ostringstream ss;
-                ss << "User: " << connection.email << std::endl;
-                ss << "Password: " << connection.password << std::endl;
-                ss << "Error: " << response.error_string << std::endl;
-                BOOST_FAIL(ss.str());
-            }
-            else
-            {
-                BOOST_CHECK( ! response.session_token.empty() );
-            }
-        });
+             if (!response.response_data)
+             {
+                 std::ostringstream ss;
+                 ss << "User: " << connection.email << std::endl;
+                 ss << "Password: " << connection.password << std::endl;
+                 ss << "Error: " << response.error_string << std::endl;
+                 BOOST_FAIL(ss.str());
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 BOOST_CHECK(!data.session_token.empty());
+             }
+         });
 
     StartWithDefaultTimeout();
 
     bool actuallyCalled = false;
-    Call(
-        api::user::get_session_token::Request(globals::connection1),
-        [&actuallyCalled, connection, this](const api::user::get_session_token::Response & response)
-        {
-            actuallyCalled = true;
-            Stop();
+    Call(api::user::get_session_token::Request(globals::connection1),
+         [&actuallyCalled, connection, this](
+                 const api::user::get_session_token::Response & response)
+         {
+             actuallyCalled = true;
+             Stop();
 
-            if ( response.error_code )
-            {
-                std::ostringstream ss;
-                ss << "User: " << connection.email << std::endl;
-                ss << "Password: " << connection.password << std::endl;
-                ss << "Error: " << response.error_string << std::endl;
-                BOOST_FAIL(ss.str());
-            }
-            else
-            {
-                BOOST_CHECK( ! response.session_token.empty() );
-            }
-        });
+             if (!response.response_data)
+             {
+                 std::ostringstream ss;
+                 ss << "User: " << connection.email << std::endl;
+                 ss << "Password: " << connection.password << std::endl;
+                 ss << "Error: " << response.error_string << std::endl;
+                 BOOST_FAIL(ss.str());
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 BOOST_CHECK(!data.session_token.empty());
+             }
+         });
 
     StartWithDefaultTimeout();
 
-    BOOST_CHECK( actuallyCalled );
+    BOOST_CHECK(actuallyCalled);
 }
 
 BOOST_AUTO_TEST_CASE(CredentialsChangeOverSessionMaintainerLive)
@@ -229,77 +237,76 @@ BOOST_AUTO_TEST_CASE(CredentialsChangeOverSessionMaintainerLive)
     const api::credentials::Email & connection2(globals::connection2);
 
     // Start with default credentials
-    Call(
-        api::user::get_info::Request(),
-        [&](const api::user::get_info::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                BOOST_CHECK_EQUAL( response.email, connection1.email );
-                Stop();
-            }
-        });
+    Call(api::user::get_info::Request(),
+         [&](const api::user::get_info::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 BOOST_CHECK_EQUAL(data.email, connection1.email);
+                 Stop();
+             }
+         });
 
     StartWithDefaultTimeout();
 
     // Call again with default credentials
     ChangeCredentials(connection1);
-    Call(
-        api::user::get_info::Request(),
-        [&](const api::user::get_info::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                BOOST_CHECK_EQUAL( response.email, connection1.email );
-                Stop();
-            }
-        });
+    Call(api::user::get_info::Request(),
+         [&](const api::user::get_info::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 BOOST_CHECK_EQUAL(data.email, connection1.email);
+                 Stop();
+             }
+         });
 
     StartWithDefaultTimeout();
 
     // Call with new credentials
     ChangeCredentials(connection2);
-    Call(
-        api::user::get_info::Request(),
-        [&](const api::user::get_info::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                BOOST_CHECK_EQUAL( response.email, connection2.email );
-                Stop();
-            }
-        });
+    Call(api::user::get_info::Request(),
+         [&](const api::user::get_info::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 BOOST_CHECK_EQUAL(data.email, connection2.email);
+                 Stop();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(UserGetLimits)
 {
-    Call(
-        api::user::get_limits::Request(),
-        [&](const api::user::get_limits::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-            }
-        });
+    Call(api::user::get_limits::Request(),
+         [&](const api::user::get_limits::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
@@ -307,60 +314,59 @@ BOOST_AUTO_TEST_CASE(UserGetLimits)
 BOOST_AUTO_TEST_CASE(GetActionToken)
 {
     api::user::get_action_token::Request request(
-        api::user::get_action_token::Type::Image);
-    Call(
-        request,
-        [&](const api::user::get_action_token::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                globals::action_token = response.action_token;
-                Success();
-            }
-        });
+            api::user::get_action_token::Type::Image);
+    Call(request, [&](const api::user::get_action_token::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 globals::action_token = data.action_token;
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(DestroyActionToken)
 {
-    Call(
-        api::user::destroy_action_token::Request(globals::action_token),
-        [&](const api::user::destroy_action_token::Response & response)
-        {
-            if ( response.error_code )
-                Fail(response);
-            else
-                Success();
-        });
+    Call(api::user::destroy_action_token::Request(globals::action_token),
+         [&](const api::user::destroy_action_token::Response & response)
+         {
+             if (!response.response_data)
+                 Fail(response);
+             else
+                 Success();
+         });
 
     StartWithDefaultTimeout();
 }
 
 BOOST_AUTO_TEST_CASE(GetLoginToken)
 {
-    api::credentials::Email email_creds = {ut::user1::username, ut::user1::password};
-    Call(
-        api::user::get_login_token::Request(email_creds),
-        [&](const api::user::get_login_token::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                Success();
-                std::cout << "Got login token: "
-                          << "https://" << ut::constants::host
-                          << "/api/user/login_with_token.php?login_token="
-                          << response.login_token << std::endl;
-            }
-        });
+    api::credentials::Email email_creds
+            = {ut::user1::username, ut::user1::password};
+    Call(api::user::get_login_token::Request(email_creds),
+         [&](const api::user::get_login_token::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 Success();
+                 std::cout << "Got login token: "
+                           << "https://" << ut::constants::host
+                           << "/api/user/login_with_token.php?login_token="
+                           << data.login_token << std::endl;
+             }
+         });
 
     StartWithDefaultTimeout();
 }
@@ -370,15 +376,16 @@ BOOST_AUTO_TEST_CASE(FetchTOS)
     namespace tos = api::user::fetch_tos;
     Call(tos::Request(), [&](const tos::Response & response)
          {
-             if (response.error_code)
+             if (!response.response_data)
              {
                  Fail(response);
              }
              else
              {
+                 const auto & data = *response.response_data;
                  Log("User accepted terms:",
-                     response.user_accepted_terms == tos::TOSAccepted::Yes);
-                 Log("Acceptance token:", response.acceptance_token);
+                     data.user_accepted_terms == tos::TOSAccepted::Yes);
+                 Log("Acceptance token:", data.acceptance_token);
                  Success();
              }
          });
@@ -388,43 +395,44 @@ BOOST_AUTO_TEST_CASE(FetchTOS)
 
 BOOST_AUTO_TEST_CASE(EkeyTest)
 {
-    api::credentials::Email email_creds = {ut::user1::username, ut::user1::password};
+    api::credentials::Email email_creds
+            = {ut::user1::username, ut::user1::password};
     boost::optional<api::credentials::Ekey> ekey_creds;
-    Call(
-        api::user::get_session_token::Request(email_creds),
-        [&](const api::user::get_session_token::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                std::cout << "Got ekey: " << response.ekey << std::endl;
-                ekey_creds = api::credentials::Ekey{response.ekey, ut::user1::password};
-                Success();
-            }
-        });
+    Call(api::user::get_session_token::Request(email_creds),
+         [&](const api::user::get_session_token::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 const auto & data = *response.response_data;
+                 std::cout << "Got ekey: " << data.ekey << std::endl;
+                 ekey_creds = api::credentials::Ekey{data.ekey,
+                                                     ut::user1::password};
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 
     // Now use the ekey
-    BOOST_REQUIRE( ekey_creds );
+    BOOST_REQUIRE(ekey_creds);
 
-    Call(
-        api::user::get_session_token::Request(*ekey_creds),
-        [&](const api::user::get_session_token::Response & response)
-        {
-            if ( response.error_code )
-            {
-                Fail(response);
-            }
-            else
-            {
-                std::cout << "Logged in with ekey!" << std::endl;
-                Success();
-            }
-        });
+    Call(api::user::get_session_token::Request(*ekey_creds),
+         [&](const api::user::get_session_token::Response & response)
+         {
+             if (!response.response_data)
+             {
+                 Fail(response);
+             }
+             else
+             {
+                 std::cout << "Logged in with ekey!" << std::endl;
+                 Success();
+             }
+         });
 
     StartWithDefaultTimeout();
 }

--- a/src/mediafire_sdk/api/unit_tests/ut_poll_changes.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_poll_changes.cpp
@@ -36,18 +36,16 @@ BOOST_AUTO_TEST_CASE(UTPollChanges)
 
     api::SessionMaintainer stm(http_config);
 
-    stm.SetLoginCredentials(
-            api::credentials::Email{username, password});
+    stm.SetLoginCredentials(api::credentials::Email{username, password});
 
     using DeviceGetStatusType = mf::api::device::get_status::Request;
     using DeviceGetChangesType = mf::api::device::get_changes::Request;
     using FolderGetInfoType = mf::api::folder::get_info::Request;
     using FileGetInfoType = mf::api::file::get_info::Request;
 
-    using PollChangesType = mf::api::PollChanges<DeviceGetStatusType,
-                                                 DeviceGetChangesType,
-                                                 FolderGetInfoType,
-                                                 FileGetInfoType>;
+    using PollChangesType
+            = mf::api::PollChanges<DeviceGetStatusType, DeviceGetChangesType,
+                                   FolderGetInfoType, FileGetInfoType>;
 
     // Response types
     using File = typename PollChangesType::File;
@@ -90,14 +88,30 @@ BOOST_AUTO_TEST_CASE(UTPollChanges)
 
         for (const auto & updated_file_info : updated_files_info)
         {
-            std::cout << "Updated File Info: " << updated_file_info.quickkey
-                      << std::endl;
+            if (updated_file_info.response_data)
+            {
+                const auto & data = *updated_file_info.response_data;
+                std::cout << "Updated File Info: " << data.quickkey
+                          << std::endl;
+            }
+            else
+            {
+                std::cout << "Updated File Info: Missing data!" << std::endl;
+            }
         }
 
         for (const auto & updated_folder_info : updated_folders_info)
         {
-            std::cout << "Updated Folder Info: "
-                      << updated_folder_info.folderkey << std::endl;
+            if (updated_folder_info.response_data)
+            {
+                const auto & data = *updated_folder_info.response_data;
+                std::cout << "Updated Folder Info: " << data.folderkey
+                          << std::endl;
+            }
+            else
+            {
+                std::cout << "Updated Folder Info: Missing data!" << std::endl;
+            }
         }
 
         for (const auto & deleted_file : deleted_files)
@@ -116,8 +130,8 @@ BOOST_AUTO_TEST_CASE(UTPollChanges)
 
     auto work_manager = mf::api::WorkManager::Create(&io_service);
 
-    auto poll_changes = PollChangesType::Create(
-            &stm, 0, work_manager, std::move(HandlePollChanges));
+    auto poll_changes = PollChangesType::Create(&stm, 0, work_manager,
+                                                std::move(HandlePollChanges));
     poll_changes->Start();
 
     io_service.run();

--- a/src/mediafire_sdk/api/unit_tests/ut_poll_foreign_changes.cpp
+++ b/src/mediafire_sdk/api/unit_tests/ut_poll_foreign_changes.cpp
@@ -48,8 +48,7 @@ BOOST_AUTO_TEST_CASE(UTPollForeignChanges)
 
     using PollForeignChangesType
             = mf::api::PollForeignChanges<DeviceGetForeignChangesType,
-                                          FolderGetInfoType,
-                                          FileGetInfoType>;
+                                          FolderGetInfoType, FileGetInfoType>;
 
     // Response types
     using File = typename PollForeignChangesType::File;
@@ -87,15 +86,32 @@ BOOST_AUTO_TEST_CASE(UTPollForeignChanges)
 
         for (const auto & updated_file_info : updated_files_info)
         {
-            std::cout << "Updated File Info: " << updated_file_info.quickkey
-                      << " " << updated_file_info.filename << std::endl;
+            if (updated_file_info.response_data)
+            {
+                const auto & data = *updated_file_info.response_data;
+                std::cout << "Updated File Info: " << data.quickkey << " "
+                          << data.filename << std::endl;
+            }
+            else
+            {
+                std::cout << "Updated File Info: Missing response data!"
+                          << std::endl;
+            }
         }
 
         for (const auto & updated_folder_info : updated_folders_info)
         {
-            std::cout << "Updated Folder Info: "
-                      << updated_folder_info.folderkey << " "
-                      << updated_folder_info.name << std::endl;
+            if (updated_folder_info.response_data)
+            {
+                const auto & data = *updated_folder_info.response_data;
+                std::cout << "Updated Folder Info: " << data.folderkey << " "
+                          << data.name << std::endl;
+            }
+            else
+            {
+                std::cout << "Updated Folder Info: Missing response data!"
+                          << std::endl;
+            }
         }
 
         for (const auto & deleted_file : deleted_files)
@@ -115,10 +131,7 @@ BOOST_AUTO_TEST_CASE(UTPollForeignChanges)
     auto work_manager = mf::api::WorkManager::Create(&io_service);
 
     auto poll_foreign_changes = PollForeignChangesType::Create(
-            &stm,
-            "t4j3iee",
-            0,
-            work_manager,
+            &stm, "t4j3iee", 0, work_manager,
             std::move(HandlePollForeignChanges));
 
     poll_foreign_changes->Start();

--- a/src/mediafire_sdk/api/upload/add_web_upload/v1_3.cpp
+++ b/src/mediafire_sdk/api/upload/add_web_upload/v1_3.cpp
@@ -85,14 +85,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.upload_key",
-            &response->upload_key ) )
+            &response_data_ptr->upload_key ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.upload_key\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/add_web_upload/v1_3.hpp
+++ b/src/mediafire_sdk/api/upload/add_web_upload/v1_3.hpp
@@ -27,15 +27,28 @@ namespace add_web_upload {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "upload/add_web_upload"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** An alpha-numeric key used with upload/poll_upload to determine the
+     * status of the file upload. */
+    std::string upload_key;
+};
+
+/**
  * @class Response
  * @brief Response from API request "upload/add_web_upload"
  */
 class Response : public ResponseBase
 {
 public:
-    /** An alpha-numeric key used with upload/poll_upload to determine the
-     * status of the file upload. */
-    std::string upload_key;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -70,7 +83,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/check/v0.cpp
+++ b/src/mediafire_sdk/api/upload/check/v0.cpp
@@ -38,7 +38,7 @@ namespace {
 using namespace v0;  // NOLINT
 bool ResumableDataFromPropertyBranch(
         Response * response,
-        Response::ResumableData * value,
+        ResponseData::ResumableData * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -205,15 +205,20 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->hash_exists = HashAlreadyInSystem::No;
-    response->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
-    response->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
-    response->file_exists = FilenameInFolder::No;
-    response->hash_different = FileExistsWithDifferentHash::No;
-    response->available_space = 0;
-    response->used_storage_size = 0;
-    response->storage_limit = 0;
-    response->storage_limit_exceeded = StorageLimitExceeded::No;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->hash_exists = HashAlreadyInSystem::No;
+    response_data_ptr->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
+    response_data_ptr->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
+    response_data_ptr->file_exists = FilenameInFolder::No;
+    response_data_ptr->hash_different = FileExistsWithDifferentHash::No;
+    response_data_ptr->available_space = 0;
+    response_data_ptr->used_storage_size = 0;
+    response_data_ptr->storage_limit = 0;
+    response_data_ptr->storage_limit_exceeded = StorageLimitExceeded::No;
 
     {
         std::string optval;
@@ -224,9 +229,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_exists = HashAlreadyInSystem::No;
+                response_data_ptr->hash_exists = HashAlreadyInSystem::No;
             else if ( optval == "yes" )
-                response->hash_exists = HashAlreadyInSystem::Yes;
+                response_data_ptr->hash_exists = HashAlreadyInSystem::Yes;
         }
     }
 
@@ -239,9 +244,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
+                response_data_ptr->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
             else if ( optval == "yes" )
-                response->hash_in_account = HashAlreadyInAccount::HashExistsInAccount;
+                response_data_ptr->hash_in_account = HashAlreadyInAccount::HashExistsInAccount;
         }
     }
 
@@ -254,9 +259,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
+                response_data_ptr->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
             else if ( optval == "yes" )
-                response->hash_in_folder = HashAlreadyInFolder::HashExistsInFolder;
+                response_data_ptr->hash_in_folder = HashAlreadyInFolder::HashExistsInFolder;
         }
     }
 
@@ -269,9 +274,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->file_exists = FilenameInFolder::No;
+                response_data_ptr->file_exists = FilenameInFolder::No;
             else if ( optval == "yes" )
-                response->file_exists = FilenameInFolder::Yes;
+                response_data_ptr->file_exists = FilenameInFolder::Yes;
         }
     }
 
@@ -284,9 +289,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_different = FileExistsWithDifferentHash::No;
+                response_data_ptr->hash_different = FileExistsWithDifferentHash::No;
             else if ( optval == "yes" )
-                response->hash_different = FileExistsWithDifferentHash::Yes;
+                response_data_ptr->hash_different = FileExistsWithDifferentHash::Yes;
         }
     }
 
@@ -298,7 +303,7 @@ void Impl::ParseResponse( Response * response )
                 "response.duplicate_quickkey",
                 &optarg) )
         {
-            response->duplicate_quickkey = optarg;
+            response_data_ptr->duplicate_quickkey = optarg;
         }
     }
 
@@ -306,19 +311,19 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.available_space",
-            &response->available_space);
+            &response_data_ptr->available_space);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.used_storage_size",
-            &response->used_storage_size);
+            &response_data_ptr->used_storage_size);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.storage_limit",
-            &response->storage_limit);
+            &response_data_ptr->storage_limit);
 
     {
         std::string optval;
@@ -329,9 +334,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->storage_limit_exceeded = StorageLimitExceeded::No;
+                response_data_ptr->storage_limit_exceeded = StorageLimitExceeded::No;
             else if ( optval == "yes" )
-                response->storage_limit_exceeded = StorageLimitExceeded::Yes;
+                response_data_ptr->storage_limit_exceeded = StorageLimitExceeded::Yes;
         }
     }
 
@@ -340,17 +345,20 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.resumable_upload");
 
-        Response::ResumableData optarg;
+        ResponseData::ResumableData optarg;
         if ( ResumableDataFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->resumable = std::move(optarg);
+            response_data_ptr->resumable = std::move(optarg);
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/check/v0.hpp
+++ b/src/mediafire_sdk/api/upload/check/v0.hpp
@@ -109,13 +109,15 @@ enum class AllUnitsReady
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/check"
+ * @class ResponseData
+ * @brief Response data from API request "upload/check"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         hash_exists(HashAlreadyInSystem::No),
         hash_in_account(HashAlreadyInAccount::HashNewToAccount),
         hash_in_folder(HashAlreadyInFolder::HashNewToFolder),
@@ -175,6 +177,17 @@ public:
 
     /** API response field "response.resumable_upload" */
     boost::optional<ResumableData> resumable;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "upload/check"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -253,7 +266,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/check/v1_2.cpp
+++ b/src/mediafire_sdk/api/upload/check/v1_2.cpp
@@ -38,7 +38,7 @@ namespace {
 using namespace v1_2;  // NOLINT
 bool ResumableDataFromPropertyBranch(
         Response * response,
-        Response::ResumableData * value,
+        ResponseData::ResumableData * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -217,15 +217,20 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->hash_exists = HashAlreadyInSystem::No;
-    response->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
-    response->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
-    response->file_exists = FilenameInFolder::No;
-    response->hash_different = FileExistsWithDifferentHash::No;
-    response->available_space = 0;
-    response->used_storage_size = 0;
-    response->storage_limit = 0;
-    response->storage_limit_exceeded = StorageLimitExceeded::No;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->hash_exists = HashAlreadyInSystem::No;
+    response_data_ptr->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
+    response_data_ptr->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
+    response_data_ptr->file_exists = FilenameInFolder::No;
+    response_data_ptr->hash_different = FileExistsWithDifferentHash::No;
+    response_data_ptr->available_space = 0;
+    response_data_ptr->used_storage_size = 0;
+    response_data_ptr->storage_limit = 0;
+    response_data_ptr->storage_limit_exceeded = StorageLimitExceeded::No;
 
     {
         std::string optval;
@@ -236,9 +241,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_exists = HashAlreadyInSystem::No;
+                response_data_ptr->hash_exists = HashAlreadyInSystem::No;
             else if ( optval == "yes" )
-                response->hash_exists = HashAlreadyInSystem::Yes;
+                response_data_ptr->hash_exists = HashAlreadyInSystem::Yes;
         }
     }
 
@@ -251,9 +256,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
+                response_data_ptr->hash_in_account = HashAlreadyInAccount::HashNewToAccount;
             else if ( optval == "yes" )
-                response->hash_in_account = HashAlreadyInAccount::HashExistsInAccount;
+                response_data_ptr->hash_in_account = HashAlreadyInAccount::HashExistsInAccount;
         }
     }
 
@@ -266,9 +271,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
+                response_data_ptr->hash_in_folder = HashAlreadyInFolder::HashNewToFolder;
             else if ( optval == "yes" )
-                response->hash_in_folder = HashAlreadyInFolder::HashExistsInFolder;
+                response_data_ptr->hash_in_folder = HashAlreadyInFolder::HashExistsInFolder;
         }
     }
 
@@ -281,9 +286,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->file_exists = FilenameInFolder::No;
+                response_data_ptr->file_exists = FilenameInFolder::No;
             else if ( optval == "yes" )
-                response->file_exists = FilenameInFolder::Yes;
+                response_data_ptr->file_exists = FilenameInFolder::Yes;
         }
     }
 
@@ -296,9 +301,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->hash_different = FileExistsWithDifferentHash::No;
+                response_data_ptr->hash_different = FileExistsWithDifferentHash::No;
             else if ( optval == "yes" )
-                response->hash_different = FileExistsWithDifferentHash::Yes;
+                response_data_ptr->hash_different = FileExistsWithDifferentHash::Yes;
         }
     }
 
@@ -310,7 +315,7 @@ void Impl::ParseResponse( Response * response )
                 "response.duplicate_quickkey",
                 &optarg) )
         {
-            response->duplicate_quickkey = optarg;
+            response_data_ptr->duplicate_quickkey = optarg;
         }
     }
 
@@ -318,19 +323,19 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.available_space",
-            &response->available_space);
+            &response_data_ptr->available_space);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.used_storage_size",
-            &response->used_storage_size);
+            &response_data_ptr->used_storage_size);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.storage_limit",
-            &response->storage_limit);
+            &response_data_ptr->storage_limit);
 
     {
         std::string optval;
@@ -341,9 +346,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->storage_limit_exceeded = StorageLimitExceeded::No;
+                response_data_ptr->storage_limit_exceeded = StorageLimitExceeded::No;
             else if ( optval == "yes" )
-                response->storage_limit_exceeded = StorageLimitExceeded::Yes;
+                response_data_ptr->storage_limit_exceeded = StorageLimitExceeded::Yes;
         }
     }
 
@@ -352,17 +357,20 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.resumable_upload");
 
-        Response::ResumableData optarg;
+        ResponseData::ResumableData optarg;
         if ( ResumableDataFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->resumable = std::move(optarg);
+            response_data_ptr->resumable = std::move(optarg);
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/check/v1_2.hpp
+++ b/src/mediafire_sdk/api/upload/check/v1_2.hpp
@@ -109,13 +109,15 @@ enum class AllUnitsReady
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/check"
+ * @class ResponseData
+ * @brief Response data from API request "upload/check"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         hash_exists(HashAlreadyInSystem::No),
         hash_in_account(HashAlreadyInAccount::HashNewToAccount),
         hash_in_folder(HashAlreadyInFolder::HashNewToFolder),
@@ -178,6 +180,17 @@ public:
 
     /** API response field "response.resumable_upload" */
     boost::optional<ResumableData> resumable;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "upload/check"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -256,7 +269,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/check/v1_3.hpp
+++ b/src/mediafire_sdk/api/upload/check/v1_3.hpp
@@ -109,13 +109,15 @@ enum class AllUnitsReady
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/check"
+ * @class ResponseData
+ * @brief Response data from API request "upload/check"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         hash_exists(HashAlreadyInSystem::No),
         hash_in_account(HashAlreadyInAccount::HashNewToAccount),
         hash_in_folder(HashAlreadyInFolder::HashNewToFolder),
@@ -178,6 +180,17 @@ public:
 
     /** API response field "response.resumable_upload" */
     boost::optional<ResumableData> resumable;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "upload/check"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -256,7 +269,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/get_web_uploads/v1_3.cpp
+++ b/src/mediafire_sdk/api/upload/get_web_uploads/v1_3.cpp
@@ -38,7 +38,7 @@ namespace {
 using namespace v1_3;  // NOLINT
 bool WebUploadFromPropertyBranch(
         Response * response,
-        Response::WebUpload * value,
+        ResponseData::WebUpload * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -257,18 +257,23 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_struct_parse TArray
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.web_uploads");
-        response->web_uploads.reserve( response->pt.size() );
+        response_data_ptr->web_uploads.reserve( response->pt.size() );
 
         for ( auto & it : branch )
         {
-            Response::WebUpload optarg;
+            ResponseData::WebUpload optarg;
             if ( WebUploadFromPropertyBranch(
                     response, &optarg, it.second) )
-                response->web_uploads.push_back(std::move(optarg));
+                response_data_ptr->web_uploads.push_back(std::move(optarg));
             else
                 return;  // error set already
         }
@@ -281,6 +286,9 @@ void Impl::ParseResponse( Response * response )
             mf::api::api_code::ContentInvalidData,
             "missing \"response.web_uploads\"");
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/get_web_uploads/v1_3.hpp
+++ b/src/mediafire_sdk/api/upload/get_web_uploads/v1_3.hpp
@@ -63,10 +63,12 @@ enum class Status
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/get_web_uploads"
+ * @class ResponseData
+ * @brief Response data from API request "upload/get_web_uploads"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     struct WebUpload
@@ -112,6 +114,17 @@ public:
     std::vector<WebUpload> web_uploads;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "upload/get_web_uploads"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -153,7 +166,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/instant/v0.cpp
+++ b/src/mediafire_sdk/api/upload/instant/v0.cpp
@@ -108,11 +108,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.quickkey",
-            &response->quickkey ) )
+            &response_data_ptr->quickkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.quickkey\"");
@@ -121,10 +126,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.filename",
-            &response->filename ) )
+            &response_data_ptr->filename ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.filename\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/instant/v0.hpp
+++ b/src/mediafire_sdk/api/upload/instant/v0.hpp
@@ -37,10 +37,12 @@ enum class ActionOnDuplicate
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/instant"
+ * @class ResponseData
+ * @brief Response data from API request "upload/instant"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.quickkey" */
@@ -48,6 +50,17 @@ public:
 
     /** API response field "response.filename" */
     std::string filename;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "upload/instant"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -129,7 +142,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/instant/v1_3.cpp
+++ b/src/mediafire_sdk/api/upload/instant/v1_3.cpp
@@ -108,11 +108,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.quickkey",
-            &response->quickkey ) )
+            &response_data_ptr->quickkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.quickkey\"");
@@ -121,7 +126,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.filename",
-            &response->filename ) )
+            &response_data_ptr->filename ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.filename\"");
@@ -130,10 +135,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.new_device_revision",
-            &response->new_device_revision ) )
+            &response_data_ptr->new_device_revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.new_device_revision\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/instant/v1_3.hpp
+++ b/src/mediafire_sdk/api/upload/instant/v1_3.hpp
@@ -37,10 +37,12 @@ enum class ActionOnDuplicate
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/instant"
+ * @class ResponseData
+ * @brief Response data from API request "upload/instant"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.quickkey" */
@@ -51,6 +53,17 @@ public:
 
     /** API response field "response.new_device_revision" */
     uint32_t new_device_revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "upload/instant"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -132,7 +145,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/poll_upload/v0.cpp
+++ b/src/mediafire_sdk/api/upload/poll_upload/v0.cpp
@@ -79,13 +79,18 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->fileerror = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->fileerror = 0;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.doupload.result",
-            &response->result ) )
+            &response_data_ptr->result ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.doupload.result\"");
@@ -98,7 +103,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.status",
                 &optarg) )
         {
-            response->status = optarg;
+            response_data_ptr->status = optarg;
         }
     }
 
@@ -106,7 +111,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.doupload.fileerror",
-            &response->fileerror);
+            &response_data_ptr->fileerror);
 
     // create_content_parse_single optional no default
     {
@@ -116,7 +121,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.filename",
                 &optarg) )
         {
-            response->filename = optarg;
+            response_data_ptr->filename = optarg;
         }
     }
 
@@ -128,7 +133,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.description",
                 &optarg) )
         {
-            response->description = optarg;
+            response_data_ptr->description = optarg;
         }
     }
 
@@ -140,7 +145,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.quickkey",
                 &optarg) )
         {
-            response->quickkey = optarg;
+            response_data_ptr->quickkey = optarg;
         }
     }
 
@@ -152,7 +157,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.size",
                 &optarg) )
         {
-            response->filesize = optarg;
+            response_data_ptr->filesize = optarg;
         }
     }
 
@@ -164,9 +169,12 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.revision",
                 &optarg) )
         {
-            response->revision = optarg;
+            response_data_ptr->revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/poll_upload/v0.hpp
+++ b/src/mediafire_sdk/api/upload/poll_upload/v0.hpp
@@ -27,13 +27,15 @@ namespace poll_upload {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "upload/poll_upload"
+ * @class ResponseData
+ * @brief Response data from API request "upload/poll_upload"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         fileerror(0)
     {}
     /** API response field "response.doupload.result" */
@@ -61,6 +63,17 @@ public:
     boost::optional<std::string> revision;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "upload/poll_upload"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -82,7 +95,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/poll_upload/v1_3.cpp
+++ b/src/mediafire_sdk/api/upload/poll_upload/v1_3.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v1_3;  // NOLINT
 bool ResumableDataFromPropertyBranch(
         Response * response,
-        Response::ResumableData * value,
+        ResponseData::ResumableData * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -200,13 +200,18 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->fileerror = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->fileerror = 0;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.doupload.result",
-            &response->result ) )
+            &response_data_ptr->result ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.doupload.result\"");
@@ -215,7 +220,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.doupload.fileerror",
-            &response->fileerror);
+            &response_data_ptr->fileerror);
 
     // create_content_parse_single optional no default
     {
@@ -225,7 +230,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.created",
                 &optarg) )
         {
-            response->created = optarg;
+            response_data_ptr->created = optarg;
         }
     }
 
@@ -237,7 +242,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.description",
                 &optarg) )
         {
-            response->description = optarg;
+            response_data_ptr->description = optarg;
         }
     }
 
@@ -249,7 +254,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.filename",
                 &optarg) )
         {
-            response->filename = optarg;
+            response_data_ptr->filename = optarg;
         }
     }
 
@@ -261,7 +266,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.hash",
                 &optarg) )
         {
-            response->hash = optarg;
+            response_data_ptr->hash = optarg;
         }
     }
 
@@ -273,7 +278,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.quickkey",
                 &optarg) )
         {
-            response->quickkey = optarg;
+            response_data_ptr->quickkey = optarg;
         }
     }
 
@@ -282,11 +287,11 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.doupload.resumable_upload");
 
-        Response::ResumableData optarg;
+        ResponseData::ResumableData optarg;
         if ( ResumableDataFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->resumable = std::move(optarg);
+            response_data_ptr->resumable = std::move(optarg);
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -302,7 +307,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.revision",
                 &optarg) )
         {
-            response->revision = optarg;
+            response_data_ptr->revision = optarg;
         }
     }
 
@@ -314,7 +319,7 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.size",
                 &optarg) )
         {
-            response->filesize = optarg;
+            response_data_ptr->filesize = optarg;
         }
     }
 
@@ -326,9 +331,12 @@ void Impl::ParseResponse( Response * response )
                 "response.doupload.status",
                 &optarg) )
         {
-            response->status = optarg;
+            response_data_ptr->status = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/poll_upload/v1_3.hpp
+++ b/src/mediafire_sdk/api/upload/poll_upload/v1_3.hpp
@@ -35,13 +35,15 @@ enum class AllUnitsReady
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/poll_upload"
+ * @class ResponseData
+ * @brief Response data from API request "upload/poll_upload"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         fileerror(0)
     {}
     struct ResumableData
@@ -98,6 +100,17 @@ public:
     boost::optional<int32_t> status;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "upload/poll_upload"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -123,7 +136,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/upload/pre_upload/v0.cpp
+++ b/src/mediafire_sdk/api/upload/pre_upload/v0.cpp
@@ -104,6 +104,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     {
         std::string optval;
         // create_content_enum_parse TSingle
@@ -113,9 +118,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->storage_limit_exceeded = StorageLimit::WithinBounds;
+                response_data_ptr->storage_limit_exceeded = StorageLimit::WithinBounds;
             else if ( optval == "yes" )
-                response->storage_limit_exceeded = StorageLimit::Exceeded;
+                response_data_ptr->storage_limit_exceeded = StorageLimit::Exceeded;
         }
     }
 
@@ -127,7 +132,7 @@ void Impl::ParseResponse( Response * response )
                 "response.storage_limit",
                 &optarg) )
         {
-            response->storage_limit = optarg;
+            response_data_ptr->storage_limit = optarg;
         }
     }
 
@@ -139,7 +144,7 @@ void Impl::ParseResponse( Response * response )
                 "response.used_storage_size",
                 &optarg) )
         {
-            response->used_storage_size = optarg;
+            response_data_ptr->used_storage_size = optarg;
         }
     }
 
@@ -152,9 +157,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->known_by_cloud = KnownByCloud::Known;
+                response_data_ptr->known_by_cloud = KnownByCloud::Known;
             else if ( optval == "yes" )
-                response->known_by_cloud = KnownByCloud::Unknown;
+                response_data_ptr->known_by_cloud = KnownByCloud::Unknown;
         }
     }
 
@@ -166,7 +171,7 @@ void Impl::ParseResponse( Response * response )
                 "response.quickkey",
                 &optarg) )
         {
-            response->quickkey = optarg;
+            response_data_ptr->quickkey = optarg;
         }
     }
 
@@ -178,7 +183,7 @@ void Impl::ParseResponse( Response * response )
                 "response.duplicate_quickkey",
                 &optarg) )
         {
-            response->duplicate_quickkey = optarg;
+            response_data_ptr->duplicate_quickkey = optarg;
         }
     }
 
@@ -191,9 +196,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->duplicate_name = DuplicateName::NoPreexistingName;
+                response_data_ptr->duplicate_name = DuplicateName::NoPreexistingName;
             else if ( optval == "yes" )
-                response->duplicate_name = DuplicateName::DuplicateNameExists;
+                response_data_ptr->duplicate_name = DuplicateName::DuplicateNameExists;
         }
     }
 
@@ -205,7 +210,7 @@ void Impl::ParseResponse( Response * response )
                 "response.resumable_upload.upload_key",
                 &optarg) )
         {
-            response->upload_key = optarg;
+            response_data_ptr->upload_key = optarg;
         }
     }
 
@@ -218,9 +223,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->all_units_ready = UnitsReady::NotReady;
+                response_data_ptr->all_units_ready = UnitsReady::NotReady;
             else if ( optval == "yes" )
-                response->all_units_ready = UnitsReady::AllUnitsReady;
+                response_data_ptr->all_units_ready = UnitsReady::AllUnitsReady;
         }
     }
 
@@ -232,7 +237,7 @@ void Impl::ParseResponse( Response * response )
                 "response.resumable_upload.number_of_units",
                 &optarg) )
         {
-            response->number_of_units = optarg;
+            response_data_ptr->number_of_units = optarg;
         }
     }
 
@@ -244,7 +249,7 @@ void Impl::ParseResponse( Response * response )
                 "response.resumable_upload.unit_size",
                 &optarg) )
         {
-            response->unit_size = optarg;
+            response_data_ptr->unit_size = optarg;
         }
     }
 
@@ -256,7 +261,7 @@ void Impl::ParseResponse( Response * response )
                 "response.resumable_upload.bitmap.count",
                 &optarg) )
         {
-            response->bitmap_count = optarg;
+            response_data_ptr->bitmap_count = optarg;
         }
     }
 
@@ -264,7 +269,7 @@ void Impl::ParseResponse( Response * response )
     try {
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.resumable_upload.bitmap.words");
-        response->bitmap_words.reserve( branch.size() );
+        response_data_ptr->bitmap_words.reserve( branch.size() );
         for ( auto & it : branch )
         {
             uint16_t result;
@@ -272,7 +277,7 @@ void Impl::ParseResponse( Response * response )
                     it.second,
                     &result ) )
             {
-                response->bitmap_words.push_back(result);
+                response_data_ptr->bitmap_words.push_back(result);
             }
             else
             {
@@ -284,6 +289,9 @@ void Impl::ParseResponse( Response * response )
     {
         // The value is optional.
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/upload/pre_upload/v0.hpp
+++ b/src/mediafire_sdk/api/upload/pre_upload/v0.hpp
@@ -77,10 +77,12 @@ enum class KnownByCloud
 };
 
 /**
- * @class Response
- * @brief Response from API request "upload/pre_upload"
+ * @class ResponseData
+ * @brief Response data from API request "upload/pre_upload"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.storage_limit_exceeded" */
@@ -121,6 +123,17 @@ public:
 
     /** API response field "response.resumable_upload.bitmap.words" */
     std::vector<uint16_t> bitmap_words;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "upload/pre_upload"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -214,7 +227,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/accept_tos/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/accept_tos/v1_3.cpp
@@ -81,6 +81,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/accept_tos/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/accept_tos/v1_3.hpp
@@ -27,12 +27,25 @@ namespace accept_tos {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/accept_tos"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/accept_tos"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/destroy_action_token/v1_0.cpp
+++ b/src/mediafire_sdk/api/user/destroy_action_token/v1_0.cpp
@@ -81,6 +81,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/destroy_action_token/v1_0.hpp
+++ b/src/mediafire_sdk/api/user/destroy_action_token/v1_0.hpp
@@ -27,12 +27,25 @@ namespace destroy_action_token {
 namespace v1_0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/destroy_action_token"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/destroy_action_token"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/destroy_action_token/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/destroy_action_token/v1_3.cpp
@@ -81,6 +81,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/destroy_action_token/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/destroy_action_token/v1_3.hpp
@@ -27,12 +27,25 @@ namespace destroy_action_token {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/destroy_action_token"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/destroy_action_token"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/fetch_tos/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/fetch_tos/v1_3.cpp
@@ -73,13 +73,18 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->user_accepted_terms = TOSAccepted::No;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->user_accepted_terms = TOSAccepted::No;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.terms_of_service.revision",
-            &response->revision ) )
+            &response_data_ptr->revision ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.terms_of_service.revision\"");
@@ -88,7 +93,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.terms_of_service.terms",
-            &response->terms ) )
+            &response_data_ptr->terms ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.terms_of_service.terms\"");
@@ -97,7 +102,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.terms_of_service.date",
-            &response->date ) )
+            &response_data_ptr->date ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.terms_of_service.date\"");
@@ -111,9 +116,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->user_accepted_terms = TOSAccepted::No;
+                response_data_ptr->user_accepted_terms = TOSAccepted::No;
             else if ( optval == "yes" )
-                response->user_accepted_terms = TOSAccepted::Yes;
+                response_data_ptr->user_accepted_terms = TOSAccepted::Yes;
         }
     }
 
@@ -121,10 +126,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.terms_of_service.acceptance_token",
-            &response->acceptance_token ) )
+            &response_data_ptr->acceptance_token ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.terms_of_service.acceptance_token\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/fetch_tos/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/fetch_tos/v1_3.hpp
@@ -35,13 +35,15 @@ enum class TOSAccepted
 };
 
 /**
- * @class Response
- * @brief Response from API request "user/fetch_tos"
+ * @class ResponseData
+ * @brief Response data from API request "user/fetch_tos"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         user_accepted_terms(TOSAccepted::No)
     {}
     /** The version of the Terms of Service. */
@@ -58,6 +60,17 @@ public:
 
     /** Token to be used with user/accept_tos. */
     std::string acceptance_token;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "user/fetch_tos"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -81,7 +94,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_action_token/v1_0.cpp
+++ b/src/mediafire_sdk/api/user/get_action_token/v1_0.cpp
@@ -92,14 +92,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.action_token",
-            &response->action_token ) )
+            &response_data_ptr->action_token ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.action_token\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_action_token/v1_0.hpp
+++ b/src/mediafire_sdk/api/user/get_action_token/v1_0.hpp
@@ -35,14 +35,27 @@ enum class Type
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/get_action_token"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.action_token" */
+    std::string action_token;
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/get_action_token"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.action_token" */
-    std::string action_token;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -78,7 +91,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_action_token/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/get_action_token/v1_3.cpp
@@ -92,14 +92,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.action_token",
-            &response->action_token ) )
+            &response_data_ptr->action_token ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.action_token\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_action_token/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/get_action_token/v1_3.hpp
@@ -35,14 +35,27 @@ enum class Type
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/get_action_token"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** API response field "response.action_token" */
+    std::string action_token;
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/get_action_token"
  */
 class Response : public ResponseBase
 {
 public:
-    /** API response field "response.action_token" */
-    std::string action_token;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -78,7 +91,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_avatar/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/get_avatar/v1_3.cpp
@@ -74,14 +74,22 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.avatar",
-            &response->avatar_url ) )
+            &response_data_ptr->avatar_url ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.avatar\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_avatar/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/get_avatar/v1_3.hpp
@@ -27,14 +27,27 @@ namespace get_avatar {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/get_avatar"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** The URL of the user's avatar. */
+    std::string avatar_url;
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/get_avatar"
  */
 class Response : public ResponseBase
 {
 public:
-    /** The URL of the user's avatar. */
-    std::string avatar_url;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -54,7 +67,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_info/v0.cpp
+++ b/src/mediafire_sdk/api/user/get_info/v0.cpp
@@ -73,17 +73,22 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->first_name = "";
-    response->last_name = "";
-    response->gender = Gender::Unknown;
-    response->birth_date = boost::posix_time::not_a_date_time;
-    response->created_datetime = boost::posix_time::not_a_date_time;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->first_name = "";
+    response_data_ptr->last_name = "";
+    response_data_ptr->gender = Gender::Unknown;
+    response_data_ptr->birth_date = boost::posix_time::not_a_date_time;
+    response_data_ptr->created_datetime = boost::posix_time::not_a_date_time;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.ekey",
-            &response->ekey ) )
+            &response_data_ptr->ekey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.ekey\"");
@@ -92,7 +97,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.email",
-            &response->email ) )
+            &response_data_ptr->email ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.email\"");
@@ -101,19 +106,19 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.user_info.first_name",
-            &response->first_name);
+            &response_data_ptr->first_name);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.user_info.last_name",
-            &response->last_name);
+            &response_data_ptr->last_name);
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.display_name",
-            &response->display_name ) )
+            &response_data_ptr->display_name ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.display_name\"");
@@ -127,11 +132,11 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "unknown" )
-                response->gender = Gender::Unknown;
+                response_data_ptr->gender = Gender::Unknown;
             else if ( optval == "male" )
-                response->gender = Gender::Male;
+                response_data_ptr->gender = Gender::Male;
             else if ( optval == "female" )
-                response->gender = Gender::Female;
+                response_data_ptr->gender = Gender::Female;
         }
     }
 
@@ -139,7 +144,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.user_info.birth_date",
-            &response->birth_date);
+            &response_data_ptr->birth_date);
 
     // create_content_parse_single optional no default
     {
@@ -149,7 +154,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.location",
                 &optarg) )
         {
-            response->location = optarg;
+            response_data_ptr->location = optarg;
         }
     }
 
@@ -161,7 +166,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.website",
                 &optarg) )
         {
-            response->website = optarg;
+            response_data_ptr->website = optarg;
         }
     }
 
@@ -174,9 +179,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "No" )
-                response->account_type = AccountType::Basic;
+                response_data_ptr->account_type = AccountType::Basic;
             else if ( optval == "Yes" )
-                response->account_type = AccountType::Premium;
+                response_data_ptr->account_type = AccountType::Premium;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -192,7 +197,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.bandwidth",
-            &response->bandwidth ) )
+            &response_data_ptr->bandwidth ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.bandwidth\"");
@@ -201,7 +206,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.user_info.created",
-            &response->created_datetime);
+            &response_data_ptr->created_datetime);
 
     {
         std::string optval;
@@ -212,9 +217,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "No" )
-                response->validated = Validated::NotValidated;
+                response_data_ptr->validated = Validated::NotValidated;
             else if ( optval == "Yes" )
-                response->validated = Validated::Validated;
+                response_data_ptr->validated = Validated::Validated;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -230,7 +235,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.max_upload_size",
-            &response->max_upload_size ) )
+            &response_data_ptr->max_upload_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.max_upload_size\"");
@@ -239,7 +244,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.max_instant_upload_size",
-            &response->max_instant_upload_size ) )
+            &response_data_ptr->max_instant_upload_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.max_instant_upload_size\"");
@@ -252,7 +257,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.tos_accepted",
                 &optarg) )
         {
-            response->tos_accepted = optarg;
+            response_data_ptr->tos_accepted = optarg;
         }
     }
 
@@ -260,7 +265,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.used_storage_size",
-            &response->used_storage_size ) )
+            &response_data_ptr->used_storage_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.used_storage_size\"");
@@ -269,7 +274,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.base_storage",
-            &response->base_storage ) )
+            &response_data_ptr->base_storage ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.base_storage\"");
@@ -278,7 +283,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.bonus_storage",
-            &response->bonus_storage ) )
+            &response_data_ptr->bonus_storage ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.bonus_storage\"");
@@ -287,7 +292,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.storage_limit",
-            &response->storage_limit ) )
+            &response_data_ptr->storage_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.storage_limit\"");
@@ -301,9 +306,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->storage_limit_exceeded = LimitExceeded::WithinBounds;
+                response_data_ptr->storage_limit_exceeded = LimitExceeded::WithinBounds;
             else if ( optval == "yes" )
-                response->storage_limit_exceeded = LimitExceeded::Exceeded;
+                response_data_ptr->storage_limit_exceeded = LimitExceeded::Exceeded;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -319,7 +324,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.options",
-            &response->options ) )
+            &response_data_ptr->options ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.options\"");
@@ -332,7 +337,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.facebook_id",
                 &optarg) )
         {
-            response->facebook_id = optarg;
+            response_data_ptr->facebook_id = optarg;
         }
     }
 
@@ -344,7 +349,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.date_created",
                 &optarg) )
         {
-            response->facebook_date_created = optarg;
+            response_data_ptr->facebook_date_created = optarg;
         }
     }
 
@@ -356,7 +361,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.facebook_url",
                 &optarg) )
         {
-            response->facebook_url = optarg;
+            response_data_ptr->facebook_url = optarg;
         }
     }
 
@@ -368,7 +373,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.name",
                 &optarg) )
         {
-            response->facebook_name = optarg;
+            response_data_ptr->facebook_name = optarg;
         }
     }
 
@@ -380,7 +385,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.firstname",
                 &optarg) )
         {
-            response->facebook_firstname = optarg;
+            response_data_ptr->facebook_firstname = optarg;
         }
     }
 
@@ -392,7 +397,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.lastname",
                 &optarg) )
         {
-            response->facebook_lastname = optarg;
+            response_data_ptr->facebook_lastname = optarg;
         }
     }
 
@@ -404,7 +409,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.hometown",
                 &optarg) )
         {
-            response->facebook_hometown = optarg;
+            response_data_ptr->facebook_hometown = optarg;
         }
     }
 
@@ -416,7 +421,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.location",
                 &optarg) )
         {
-            response->facebook_location = optarg;
+            response_data_ptr->facebook_location = optarg;
         }
     }
 
@@ -428,7 +433,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.i18n",
                 &optarg) )
         {
-            response->facebook_i18n = optarg;
+            response_data_ptr->facebook_i18n = optarg;
         }
     }
 
@@ -440,7 +445,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.facebook.timezone",
                 &optarg) )
         {
-            response->facebook_timezone = optarg;
+            response_data_ptr->facebook_timezone = optarg;
         }
     }
 
@@ -453,9 +458,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->facebook_linked = FacebookLinked::Unlinked;
+                response_data_ptr->facebook_linked = FacebookLinked::Unlinked;
             else if ( optval == "yes" )
-                response->facebook_linked = FacebookLinked::Linked;
+                response_data_ptr->facebook_linked = FacebookLinked::Linked;
         }
     }
 
@@ -467,7 +472,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.twitter.twitter_id",
                 &optarg) )
         {
-            response->twitter_id = optarg;
+            response_data_ptr->twitter_id = optarg;
         }
     }
 
@@ -479,7 +484,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.twitter.date_created",
                 &optarg) )
         {
-            response->twitter_date_created = optarg;
+            response_data_ptr->twitter_date_created = optarg;
         }
     }
 
@@ -491,7 +496,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.twitter.screen_name",
                 &optarg) )
         {
-            response->twitter_screen_name = optarg;
+            response_data_ptr->twitter_screen_name = optarg;
         }
     }
 
@@ -503,7 +508,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.twitter.name",
                 &optarg) )
         {
-            response->twitter_name = optarg;
+            response_data_ptr->twitter_name = optarg;
         }
     }
 
@@ -515,7 +520,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.twitter.i18n",
                 &optarg) )
         {
-            response->twitter_i18n = optarg;
+            response_data_ptr->twitter_i18n = optarg;
         }
     }
 
@@ -528,11 +533,14 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->twitter_linked = TwitterLinked::Unlinked;
+                response_data_ptr->twitter_linked = TwitterLinked::Unlinked;
             else if ( optval == "yes" )
-                response->twitter_linked = TwitterLinked::Linked;
+                response_data_ptr->twitter_linked = TwitterLinked::Linked;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_info/v0.hpp
+++ b/src/mediafire_sdk/api/user/get_info/v0.hpp
@@ -77,13 +77,15 @@ enum class TwitterLinked
 };
 
 /**
- * @class Response
- * @brief Response from API request "user/get_info"
+ * @class ResponseData
+ * @brief Response data from API request "user/get_info"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         first_name(""),
         last_name(""),
         gender(Gender::Unknown),
@@ -208,6 +210,17 @@ public:
     boost::optional<TwitterLinked> twitter_linked;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "user/get_info"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -234,7 +247,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_info/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/get_info/v1_3.cpp
@@ -27,7 +27,7 @@ namespace {
 using namespace v1_3;  // NOLINT
 bool FacebookFromPropertyBranch(
         Response * response,
-        Response::Facebook * value,
+        ResponseData::Facebook * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -185,7 +185,7 @@ bool FacebookFromPropertyBranch(
 using namespace v1_3;  // NOLINT
 bool TwitterFromPropertyBranch(
         Response * response,
-        Response::Twitter * value,
+        ResponseData::Twitter * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -283,7 +283,7 @@ bool TwitterFromPropertyBranch(
 using namespace v1_3;  // NOLINT
 bool GmailFromPropertyBranch(
         Response * response,
-        Response::Gmail * value,
+        ResponseData::Gmail * value,
         const boost::property_tree::wptree & pt
     )
 {
@@ -478,17 +478,22 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->first_name = "";
-    response->last_name = "";
-    response->gender = Gender::Unknown;
-    response->birth_date = boost::posix_time::not_a_date_time;
-    response->created_datetime = boost::posix_time::not_a_date_time;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->first_name = "";
+    response_data_ptr->last_name = "";
+    response_data_ptr->gender = Gender::Unknown;
+    response_data_ptr->birth_date = boost::posix_time::not_a_date_time;
+    response_data_ptr->created_datetime = boost::posix_time::not_a_date_time;
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.ekey",
-            &response->ekey ) )
+            &response_data_ptr->ekey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.ekey\"");
@@ -497,7 +502,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.email",
-            &response->email ) )
+            &response_data_ptr->email ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.email\"");
@@ -506,19 +511,19 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.user_info.first_name",
-            &response->first_name);
+            &response_data_ptr->first_name);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.user_info.last_name",
-            &response->last_name);
+            &response_data_ptr->last_name);
 
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.display_name",
-            &response->display_name ) )
+            &response_data_ptr->display_name ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.display_name\"");
@@ -532,11 +537,11 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "unknown" )
-                response->gender = Gender::Unknown;
+                response_data_ptr->gender = Gender::Unknown;
             else if ( optval == "male" )
-                response->gender = Gender::Male;
+                response_data_ptr->gender = Gender::Male;
             else if ( optval == "female" )
-                response->gender = Gender::Female;
+                response_data_ptr->gender = Gender::Female;
         }
     }
 
@@ -544,7 +549,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.user_info.birth_date",
-            &response->birth_date);
+            &response_data_ptr->birth_date);
 
     // create_content_parse_single optional no default
     {
@@ -554,7 +559,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.location",
                 &optarg) )
         {
-            response->location = optarg;
+            response_data_ptr->location = optarg;
         }
     }
 
@@ -566,7 +571,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.website",
                 &optarg) )
         {
-            response->website = optarg;
+            response_data_ptr->website = optarg;
         }
     }
 
@@ -579,9 +584,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->account_type = AccountType::Basic;
+                response_data_ptr->account_type = AccountType::Basic;
             else if ( optval == "yes" )
-                response->account_type = AccountType::Premium;
+                response_data_ptr->account_type = AccountType::Premium;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -597,7 +602,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.bandwidth",
-            &response->bandwidth ) )
+            &response_data_ptr->bandwidth ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.bandwidth\"");
@@ -606,7 +611,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.user_info.created",
-            &response->created_datetime);
+            &response_data_ptr->created_datetime);
 
     {
         std::string optval;
@@ -617,9 +622,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->validated = Validated::NotValidated;
+                response_data_ptr->validated = Validated::NotValidated;
             else if ( optval == "yes" )
-                response->validated = Validated::Validated;
+                response_data_ptr->validated = Validated::Validated;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -639,7 +644,7 @@ void Impl::ParseResponse( Response * response )
                 "response.user_info.tos_accepted",
                 &optarg) )
         {
-            response->tos_accepted = optarg;
+            response_data_ptr->tos_accepted = optarg;
         }
     }
 
@@ -647,7 +652,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.used_storage_size",
-            &response->used_storage_size ) )
+            &response_data_ptr->used_storage_size ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.used_storage_size\"");
@@ -656,7 +661,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.base_storage",
-            &response->base_storage ) )
+            &response_data_ptr->base_storage ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.base_storage\"");
@@ -665,7 +670,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.bonus_storage",
-            &response->bonus_storage ) )
+            &response_data_ptr->bonus_storage ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.bonus_storage\"");
@@ -674,7 +679,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.storage_limit",
-            &response->storage_limit ) )
+            &response_data_ptr->storage_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.storage_limit\"");
@@ -688,9 +693,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->storage_limit_exceeded = LimitExceeded::WithinBounds;
+                response_data_ptr->storage_limit_exceeded = LimitExceeded::WithinBounds;
             else if ( optval == "yes" )
-                response->storage_limit_exceeded = LimitExceeded::Exceeded;
+                response_data_ptr->storage_limit_exceeded = LimitExceeded::Exceeded;
             else
                 return_error(
                     mf::api::api_code::ContentInvalidData,
@@ -706,7 +711,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.user_info.options",
-            &response->options ) )
+            &response_data_ptr->options ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.user_info.options\"");
@@ -716,11 +721,11 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.user_info.facebook");
 
-        Response::Facebook optarg;
+        ResponseData::Facebook optarg;
         if ( FacebookFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->facebook = std::move(optarg);
+            response_data_ptr->facebook = std::move(optarg);
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -733,11 +738,11 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.user_info.twitter");
 
-        Response::Twitter optarg;
+        ResponseData::Twitter optarg;
         if ( TwitterFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->twitter = std::move(optarg);
+            response_data_ptr->twitter = std::move(optarg);
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
@@ -750,17 +755,20 @@ void Impl::ParseResponse( Response * response )
         const boost::property_tree::wptree & branch =
             response->pt.get_child(L"response.user_info.gmail");
 
-        Response::Gmail optarg;
+        ResponseData::Gmail optarg;
         if ( GmailFromPropertyBranch(
                 response, &optarg, branch) )
         {
-            response->gmail = std::move(optarg);
+            response_data_ptr->gmail = std::move(optarg);
         }
     }
     catch(boost::property_tree::ptree_bad_path & err)
     {
         // Is optional
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_info/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/get_info/v1_3.hpp
@@ -69,13 +69,15 @@ enum class Linked
 };
 
 /**
- * @class Response
- * @brief Response from API request "user/get_info"
+ * @class ResponseData
+ * @brief Response data from API request "user/get_info"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         first_name(""),
         last_name(""),
         gender(Gender::Unknown),
@@ -239,6 +241,17 @@ public:
     boost::optional<Gmail> gmail;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "user/get_info"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -264,7 +277,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_limits/v0.cpp
+++ b/src/mediafire_sdk/api/user/get_limits/v0.cpp
@@ -74,11 +74,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.storage_base",
-            &response->storage_base ) )
+            &response_data_ptr->storage_base ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.storage_base\"");
@@ -87,7 +92,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.storage_bonus",
-            &response->storage_bonus ) )
+            &response_data_ptr->storage_bonus ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.storage_bonus\"");
@@ -96,7 +101,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.storage_limit",
-            &response->storage_limit ) )
+            &response_data_ptr->storage_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.storage_limit\"");
@@ -105,7 +110,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.storage_used",
-            &response->storage_used ) )
+            &response_data_ptr->storage_used ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.storage_used\"");
@@ -114,7 +119,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.bandwidth_limit",
-            &response->bandwidth_limit ) )
+            &response_data_ptr->bandwidth_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.bandwidth_limit\"");
@@ -123,7 +128,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.bandwidth_used",
-            &response->bandwidth_used ) )
+            &response_data_ptr->bandwidth_used ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.bandwidth_used\"");
@@ -132,7 +137,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.collaboration_limit",
-            &response->collaboration_limit ) )
+            &response_data_ptr->collaboration_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.collaboration_limit\"");
@@ -141,7 +146,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.collaboration_today",
-            &response->collaboration_today ) )
+            &response_data_ptr->collaboration_today ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.collaboration_today\"");
@@ -150,7 +155,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.one_time_downloads_limit",
-            &response->one_time_downloads_limit ) )
+            &response_data_ptr->one_time_downloads_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.one_time_downloads_limit\"");
@@ -159,7 +164,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.one_time_downloads_today",
-            &response->one_time_downloads_today ) )
+            &response_data_ptr->one_time_downloads_today ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.one_time_downloads_today\"");
@@ -168,7 +173,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.streaming_bandwidth_limit",
-            &response->streaming_bandwidth_limit ) )
+            &response_data_ptr->streaming_bandwidth_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.streaming_bandwidth_limit\"");
@@ -177,7 +182,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.streaming_bandwidth_today",
-            &response->streaming_bandwidth_today ) )
+            &response_data_ptr->streaming_bandwidth_today ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.streaming_bandwidth_today\"");
@@ -186,10 +191,13 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.upload_size_limit",
-            &response->upload_size_limit ) )
+            &response_data_ptr->upload_size_limit ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.upload_size_limit\"");
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_limits/v0.hpp
+++ b/src/mediafire_sdk/api/user/get_limits/v0.hpp
@@ -27,10 +27,12 @@ namespace get_limits {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "user/get_limits"
+ * @class ResponseData
+ * @brief Response data from API request "user/get_limits"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** API response field "response.storage_base" */
@@ -73,6 +75,17 @@ public:
     uint64_t upload_size_limit;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "user/get_limits"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -90,7 +103,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_limits/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/get_limits/v1_3.cpp
@@ -73,97 +73,105 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->storage_base = 0;
-    response->storage_bonus = 0;
-    response->storage_limit = 0;
-    response->storage_used = 0;
-    response->bandwidth_limit = 0;
-    response->bandwidth_used = 0;
-    response->collaboration_limit = 0;
-    response->collaboration_today = 0;
-    response->one_time_downloads_limit = 0;
-    response->one_time_downloads_today = 0;
-    response->streaming_bandwidth_limit = 0;
-    response->streaming_bandwidth_today = 0;
-    response->upload_size_limit = 0;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->storage_base = 0;
+    response_data_ptr->storage_bonus = 0;
+    response_data_ptr->storage_limit = 0;
+    response_data_ptr->storage_used = 0;
+    response_data_ptr->bandwidth_limit = 0;
+    response_data_ptr->bandwidth_used = 0;
+    response_data_ptr->collaboration_limit = 0;
+    response_data_ptr->collaboration_today = 0;
+    response_data_ptr->one_time_downloads_limit = 0;
+    response_data_ptr->one_time_downloads_today = 0;
+    response_data_ptr->streaming_bandwidth_limit = 0;
+    response_data_ptr->streaming_bandwidth_today = 0;
+    response_data_ptr->upload_size_limit = 0;
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.storage_base",
-            &response->storage_base);
+            &response_data_ptr->storage_base);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.storage_bonus",
-            &response->storage_bonus);
+            &response_data_ptr->storage_bonus);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.storage_limit",
-            &response->storage_limit);
+            &response_data_ptr->storage_limit);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.storage_used",
-            &response->storage_used);
+            &response_data_ptr->storage_used);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.bandwidth_limit",
-            &response->bandwidth_limit);
+            &response_data_ptr->bandwidth_limit);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.bandwidth_used",
-            &response->bandwidth_used);
+            &response_data_ptr->bandwidth_used);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.collaboration_limit",
-            &response->collaboration_limit);
+            &response_data_ptr->collaboration_limit);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.collaboration_today",
-            &response->collaboration_today);
+            &response_data_ptr->collaboration_today);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_downloads_limit",
-            &response->one_time_downloads_limit);
+            &response_data_ptr->one_time_downloads_limit);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.one_time_downloads_today",
-            &response->one_time_downloads_today);
+            &response_data_ptr->one_time_downloads_today);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.streaming_bandwidth_limit",
-            &response->streaming_bandwidth_limit);
+            &response_data_ptr->streaming_bandwidth_limit);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.streaming_bandwidth_today",
-            &response->streaming_bandwidth_today);
+            &response_data_ptr->streaming_bandwidth_today);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.upload_size_limit",
-            &response->upload_size_limit);
+            &response_data_ptr->upload_size_limit);
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_limits/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/get_limits/v1_3.hpp
@@ -27,13 +27,15 @@ namespace get_limits {
 namespace v1_3 {
 
 /**
- * @class Response
- * @brief Response from API request "user/get_limits"
+ * @class ResponseData
+ * @brief Response data from API request "user/get_limits"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         storage_base(0),
         storage_bonus(0),
         storage_limit(0),
@@ -88,6 +90,17 @@ public:
     uint64_t upload_size_limit;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "user/get_limits"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -105,7 +118,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/get_login_token.cpp
+++ b/src/mediafire_sdk/api/user/get_login_token.cpp
@@ -18,61 +18,64 @@
 
 namespace v0 = mf::api::user::get_login_token::v0;
 
-namespace {
+namespace
+{
 std::string AssembleQueryParts(std::map<std::string, std::string> & parts)
 {
     std::string query;
     char divider = '?';
-    for ( const auto & it : parts )
+    for (const auto & it : parts)
     {
-        query += divider + it.first + '=' +
-            mf::utils::url::get_parameter::Encode(it.second);
+        query += divider + it.first + '='
+                 + mf::utils::url::get_parameter::Encode(it.second);
         divider = '&';
     }
     return query;
 }
 class CredentialsParts
-    : public boost::static_visitor< std::map<std::string, std::string> >
+        : public boost::static_visitor<std::map<std::string, std::string>>
 {
 public:
     std::map<std::string, std::string> operator()(
-            const mf::api::credentials::Email & email_credentials
-        ) const
+            const mf::api::credentials::Email & email_credentials) const
     {
         std::map<std::string, std::string> parts;
 
         parts.emplace(std::string("email"), email_credentials.email);
         parts.emplace(std::string("password"), email_credentials.password);
-        parts.emplace(std::string("signature"), app_constants::BuildSignature(
-                email_credentials.email + email_credentials.password ) );
+        parts.emplace(
+                std::string("signature"),
+                app_constants::BuildSignature(email_credentials.email
+                                              + email_credentials.password));
 
         return parts;
     }
 
     std::map<std::string, std::string> operator()(
-            const mf::api::credentials::Ekey & ekey_credentials
-        ) const
+            const mf::api::credentials::Ekey & ekey_credentials) const
     {
         std::map<std::string, std::string> parts;
 
         parts.emplace(std::string("ekey"), ekey_credentials.ekey);
         parts.emplace(std::string("password"), ekey_credentials.password);
-        parts.emplace(std::string("signature"), app_constants::BuildSignature(
-                ekey_credentials.ekey + ekey_credentials.password ) );
+        parts.emplace(
+                std::string("signature"),
+                app_constants::BuildSignature(ekey_credentials.ekey
+                                              + ekey_credentials.password));
 
         return parts;
     }
 
     std::map<std::string, std::string> operator()(
-            const mf::api::credentials::Facebook & facebook_credentials
-        ) const
+            const mf::api::credentials::Facebook & facebook_credentials) const
     {
         std::map<std::string, std::string> parts;
 
         parts.emplace(std::string("fb_access_token"),
-            facebook_credentials.fb_access_token);
-        parts.emplace(std::string("signature"), app_constants::BuildSignature(
-                facebook_credentials.fb_access_token ) );
+                      facebook_credentials.fb_access_token);
+        parts.emplace(std::string("signature"),
+                      app_constants::BuildSignature(
+                              facebook_credentials.fb_access_token));
 
         return parts;
     }
@@ -80,9 +83,8 @@ public:
 }  // namespace
 
 mf::api::user::get_login_token::v0::Request::Request(
-        const Credentials & credentials
-    ) :
-    credentials_(credentials)
+        const Credentials & credentials)
+        : credentials_(credentials)
 {
 }
 
@@ -91,18 +93,19 @@ std::string v0::Request::Url(std::string hostname) const
     std::map<std::string, std::string> query_parts;
 
     static const bool has_app_id = (app_constants::kAppId != nullptr
-        && std::strlen(app_constants::kAppId) > 0);
+                                    && std::strlen(app_constants::kAppId) > 0);
 
     if (has_app_id)
-        query_parts.emplace(std::string("application_id"), app_constants::kAppId);
+        query_parts.emplace(std::string("application_id"),
+                            app_constants::kAppId);
     else
-        assert( !"app_constants::kAppId not defined!" );
+        assert(!"app_constants::kAppId not defined!");
 
     query_parts.emplace(std::string("response_format"), std::string("json"));
 
-    const std::map<std::string, std::string> credential_parts =
-        boost::apply_visitor(CredentialsParts(), credentials_);
-    query_parts.insert( credential_parts.begin(), credential_parts.end() );
+    const std::map<std::string, std::string> credential_parts
+            = boost::apply_visitor(CredentialsParts(), credentials_);
+    query_parts.insert(credential_parts.begin(), credential_parts.end());
 
     std::string url;
     url = "https://" + hostname + "/api/user/get_login_token.php";
@@ -110,49 +113,57 @@ std::string v0::Request::Url(std::string hostname) const
     return url;
 }
 
-void v0::Request::HandleContent(
-        const std::string & url,
-        const mf::http::Headers & headers,
-        const std::string & content)
+void v0::Request::HandleContent(const std::string & url,
+                                const mf::http::Headers & headers,
+                                const std::string & content)
 {
-    assert( callback_ );
-    if ( ! callback_ )
+    assert(callback_);
+    if (!callback_)
         return;
 
     ResponseType response;
     response.InitializeWithContent(url, "", headers, content);
 
-#   ifdef OUTPUT_DEBUG // Debug code
+    ResponseData response_data;
+
+#ifdef OUTPUT_DEBUG  // Debug code
     std::cout << "Got content:\n" << content << std::endl;
 
     std::wostringstream ss;
-    boost::property_tree::write_json( ss, response.pt );
-    std::cout << "Got JSON:\n" << mf::utils::wide_to_bytes(ss.str()) << std::endl;
-#   endif
+    boost::property_tree::write_json(ss, response.pt);
+    std::cout << "Got JSON:\n" << mf::utils::wide_to_bytes(ss.str())
+              << std::endl;
+#endif
 
-    if ( ! response.error_code )
     {
-        GetIfExists( response.pt, "response.pkey", &response.pkey );
+        std::string pkey;
+        if (GetIfExists(response.pt, "response.pkey", &pkey))
+            response.pkey = pkey;
+    }
 
-        if ( ! GetIfExists( response.pt, "response.login_token",
-                    &response.login_token ) )
+    if (!response.error_code)
+    {
+        if (!GetIfExists(response.pt, "response.login_token",
+                         &response_data.login_token))
         {
-            response.error_code = make_error_code(
-                    mf::api::api_code::ContentInvalidData );
+            response.error_code
+                    = make_error_code(mf::api::api_code::ContentInvalidData);
             response.error_string = "missing session token";
         }
     }
 
+    // Only return data structure if no errors
+    if (!response.error_code)
+        response.response_data = std::move(response_data);
+
     callback_(response);
 }
 
-void v0::Request::HandleError(
-        const std::string & url,
-        std::error_code ec,
-        const std::string & error_string
-    )
+void v0::Request::HandleError(const std::string & url,
+                              std::error_code ec,
+                              const std::string & error_string)
 {
-    if ( ! callback_ )
+    if (!callback_)
         return;
 
     ResponseType response;

--- a/src/mediafire_sdk/api/user/get_login_token.hpp
+++ b/src/mediafire_sdk/api/user/get_login_token.hpp
@@ -14,11 +14,29 @@
 #include "mediafire_sdk/api/response_base.hpp"
 #include "mediafire_sdk/api/credentials.hpp"
 
-namespace mf {
-namespace api {
-namespace user {
-namespace get_login_token {
-namespace v0 {
+namespace mf
+{
+namespace api
+{
+namespace user
+{
+namespace get_login_token
+{
+namespace v0
+{
+
+/**
+ * @class ResponseData
+ * @brief ResponseData from API request "user/get_login_token"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+    /** Token used to log into user's account. */
+    std::string login_token;
+};
 
 /**
  * @class Response
@@ -27,11 +45,11 @@ namespace v0 {
 class Response : public ResponseBase
 {
 public:
-    /** Token used to log into user's account. */
-    std::string login_token;
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 
-    /** Password hash used to determine if password has been modified. */
-    std::string pkey;
+    /** Unique password identifier.  Changes when password changes. */
+    boost::optional<std::string> pkey;
 };
 
 /**
@@ -44,13 +62,10 @@ public:
     typedef Response ResponseType;
 
     /** Callback type */
-    typedef std::function<
-        void(
-                const ResponseType & data
-            )> CallbackType;
+    typedef std::function<void(const ResponseType & data)> CallbackType;
 
     /** Requester/SessionMaintainer expected method. */
-    void SetCallback( CallbackType callback_function )
+    void SetCallback(CallbackType callback_function)
     {
         callback_ = callback_function;
     };
@@ -60,22 +75,20 @@ public:
      *
      * @param[in] credentials  API credentials for login token
      */
-    Request( const Credentials & credentials );
+    Request(const Credentials & credentials);
 
     /** Requester expected method. */
     std::string Url(std::string hostname) const;
 
     /** Requester expected method. */
-    void HandleContent(
-            const std::string & url,
-            const mf::http::Headers & headers,
-            const std::string & content);
+    void HandleContent(const std::string & url,
+                       const mf::http::Headers & headers,
+                       const std::string & content);
 
     /** Requester expected method. */
-    void HandleError(
-            const std::string & url,
-            std::error_code ec,
-            const std::string & error_string);
+    void HandleError(const std::string & url,
+                     std::error_code ec,
+                     const std::string & error_string);
 
 private:
     const Credentials credentials_;

--- a/src/mediafire_sdk/api/user/get_session_token/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/get_session_token/v1_3.hpp
@@ -32,10 +32,12 @@ enum TokenVersion
 };
 
 /**
- * @class Response
- * @brief Response from API request "user/get_session_token"
+ * @class ResponseData
+ * @brief Response data from API request "user/get_session_token"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     // The rest must be set by implementer
@@ -44,11 +46,22 @@ public:
     /** Unique user identifier. Will never change. */
     std::string ekey;
 
-    /** Unique password identifier.  Changes when password changes. */
-    std::string pkey;
-
     std::string time;
     int secret_key;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "user/get_session_token"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+
+    /** Unique password identifier.  Changes when password changes. */
+    boost::optional<std::string> pkey;
 };
 
 /**

--- a/src/mediafire_sdk/api/user/get_settings/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/get_settings/v1_3.cpp
@@ -73,18 +73,23 @@ void Impl::ParseResponse( Response * response )
         SetError(response, error_type, error_message);                         \
         return;                                                                \
     }
-    response->email_address_validated = EmailValidation::NeedsValidation;
-    response->instant_uploads = InstantUploads::Disabled;
-    response->show_download_page_me_from_me = DownloadPage::NotSkipped;
-    response->show_download_page_me_from_others = DownloadPage::NotSkipped;
-    response->show_download_page_others_from_me = DownloadPage::NotSkipped;
-    response->auto_bandwidth = AutoBandwidth::NoAction;
-    response->used_storage_size = 0;
-    response->storage_limit = 0;
-    response->storage_limit_exceeded = StorageLimit::InBounds;
-    response->previous_file_versions = 0;
-    response->share_link_status = ShareLinkStatus::Inherit;
-    response->collect_metadata = CollectMetadata::No;
+
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+    response_data_ptr->email_address_validated = EmailValidation::NeedsValidation;
+    response_data_ptr->instant_uploads = InstantUploads::Disabled;
+    response_data_ptr->show_download_page_me_from_me = DownloadPage::NotSkipped;
+    response_data_ptr->show_download_page_me_from_others = DownloadPage::NotSkipped;
+    response_data_ptr->show_download_page_others_from_me = DownloadPage::NotSkipped;
+    response_data_ptr->auto_bandwidth = AutoBandwidth::NoAction;
+    response_data_ptr->used_storage_size = 0;
+    response_data_ptr->storage_limit = 0;
+    response_data_ptr->storage_limit_exceeded = StorageLimit::InBounds;
+    response_data_ptr->previous_file_versions = 0;
+    response_data_ptr->share_link_status = ShareLinkStatus::Inherit;
+    response_data_ptr->collect_metadata = CollectMetadata::No;
 
     {
         std::string optval;
@@ -95,9 +100,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->email_address_validated = EmailValidation::NeedsValidation;
+                response_data_ptr->email_address_validated = EmailValidation::NeedsValidation;
             else if ( optval == "yes" )
-                response->email_address_validated = EmailValidation::Validated;
+                response_data_ptr->email_address_validated = EmailValidation::Validated;
         }
     }
 
@@ -110,9 +115,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->instant_uploads = InstantUploads::Disabled;
+                response_data_ptr->instant_uploads = InstantUploads::Disabled;
             else if ( optval == "yes" )
-                response->instant_uploads = InstantUploads::Enabled;
+                response_data_ptr->instant_uploads = InstantUploads::Enabled;
         }
     }
 
@@ -125,9 +130,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->show_download_page_me_from_me = DownloadPage::Skipped;
+                response_data_ptr->show_download_page_me_from_me = DownloadPage::Skipped;
             else if ( optval == "yes" )
-                response->show_download_page_me_from_me = DownloadPage::NotSkipped;
+                response_data_ptr->show_download_page_me_from_me = DownloadPage::NotSkipped;
         }
     }
 
@@ -140,9 +145,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->show_download_page_me_from_others = DownloadPage::Skipped;
+                response_data_ptr->show_download_page_me_from_others = DownloadPage::Skipped;
             else if ( optval == "yes" )
-                response->show_download_page_me_from_others = DownloadPage::NotSkipped;
+                response_data_ptr->show_download_page_me_from_others = DownloadPage::NotSkipped;
         }
     }
 
@@ -155,9 +160,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->show_download_page_others_from_me = DownloadPage::Skipped;
+                response_data_ptr->show_download_page_others_from_me = DownloadPage::Skipped;
             else if ( optval == "yes" )
-                response->show_download_page_others_from_me = DownloadPage::NotSkipped;
+                response_data_ptr->show_download_page_others_from_me = DownloadPage::NotSkipped;
         }
     }
 
@@ -170,9 +175,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->auto_bandwidth = AutoBandwidth::NoAction;
+                response_data_ptr->auto_bandwidth = AutoBandwidth::NoAction;
             else if ( optval == "yes" )
-                response->auto_bandwidth = AutoBandwidth::PurchaseMoreAutomatically;
+                response_data_ptr->auto_bandwidth = AutoBandwidth::PurchaseMoreAutomatically;
         }
     }
 
@@ -180,13 +185,13 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.settings.used_storage_size",
-            &response->used_storage_size);
+            &response_data_ptr->used_storage_size);
 
     // create_content_parse_single optional with default
     GetIfExists(
             response->pt,
             "response.settings.storage_limit",
-            &response->storage_limit);
+            &response_data_ptr->storage_limit);
 
     {
         std::string optval;
@@ -197,9 +202,9 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->storage_limit_exceeded = StorageLimit::InBounds;
+                response_data_ptr->storage_limit_exceeded = StorageLimit::InBounds;
             else if ( optval == "yes" )
-                response->storage_limit_exceeded = StorageLimit::Exceeded;
+                response_data_ptr->storage_limit_exceeded = StorageLimit::Exceeded;
         }
     }
 
@@ -207,7 +212,7 @@ void Impl::ParseResponse( Response * response )
     GetIfExists(
             response->pt,
             "response.settings.previous_file_versions",
-            &response->previous_file_versions);
+            &response_data_ptr->previous_file_versions);
 
     {
         std::string optval;
@@ -218,11 +223,11 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "disabled" )
-                response->share_link_status = ShareLinkStatus::Disabled;
+                response_data_ptr->share_link_status = ShareLinkStatus::Disabled;
             else if ( optval == "enabled" )
-                response->share_link_status = ShareLinkStatus::Enabled;
+                response_data_ptr->share_link_status = ShareLinkStatus::Enabled;
             else if ( optval == "inherit" )
-                response->share_link_status = ShareLinkStatus::Inherit;
+                response_data_ptr->share_link_status = ShareLinkStatus::Inherit;
         }
     }
 
@@ -235,11 +240,14 @@ void Impl::ParseResponse( Response * response )
                 &optval) )
         {
             if ( optval == "no" )
-                response->collect_metadata = CollectMetadata::No;
+                response_data_ptr->collect_metadata = CollectMetadata::No;
             else if ( optval == "yes" )
-                response->collect_metadata = CollectMetadata::Yes;
+                response_data_ptr->collect_metadata = CollectMetadata::Yes;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/get_settings/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/get_settings/v1_3.hpp
@@ -85,13 +85,15 @@ enum class CollectMetadata
 };
 
 /**
- * @class Response
- * @brief Response from API request "user/get_settings"
+ * @class ResponseData
+ * @brief Response data from API request "user/get_settings"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
-    Response() :
+    ResponseData() :
         email_address_validated(EmailValidation::NeedsValidation),
         instant_uploads(InstantUploads::Disabled),
         show_download_page_me_from_me(DownloadPage::NotSkipped),
@@ -147,6 +149,17 @@ public:
     CollectMetadata collect_metadata;
 };
 
+/**
+ * @class Response
+ * @brief Response from API request "user/get_settings"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
+};
+
 class Impl;
 
 /**
@@ -174,7 +187,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/link_facebook/v0.cpp
+++ b/src/mediafire_sdk/api/user/link_facebook/v0.cpp
@@ -81,6 +81,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/link_facebook/v0.hpp
+++ b/src/mediafire_sdk/api/user/link_facebook/v0.hpp
@@ -27,12 +27,25 @@ namespace link_facebook {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/link_facebook"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/link_facebook"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/link_facebook/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/link_facebook/v1_3.cpp
@@ -81,6 +81,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/link_facebook/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/link_facebook/v1_3.hpp
@@ -27,12 +27,25 @@ namespace link_facebook {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/link_facebook"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/link_facebook"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/link_gmail/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/link_gmail/v1_3.cpp
@@ -81,6 +81,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/link_gmail/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/link_gmail/v1_3.hpp
@@ -27,12 +27,25 @@ namespace link_gmail {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/link_gmail"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/link_gmail"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -56,7 +69,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/link_twitter/v0.cpp
+++ b/src/mediafire_sdk/api/user/link_twitter/v0.cpp
@@ -85,6 +85,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/link_twitter/v0.hpp
+++ b/src/mediafire_sdk/api/user/link_twitter/v0.hpp
@@ -27,12 +27,25 @@ namespace link_twitter {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/link_twitter"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/link_twitter"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -58,7 +71,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/link_twitter/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/link_twitter/v1_3.cpp
@@ -85,6 +85,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/link_twitter/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/link_twitter/v1_3.hpp
@@ -27,12 +27,25 @@ namespace link_twitter {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/link_twitter"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/link_twitter"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -58,7 +71,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/set_avatar/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/set_avatar/v1_3.cpp
@@ -88,6 +88,11 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single optional no default
     {
         std::string optarg;
@@ -96,7 +101,7 @@ void Impl::ParseResponse( Response * response )
                 "response.quick_key",
                 &optarg) )
         {
-            response->quickkey = optarg;
+            response_data_ptr->quickkey = optarg;
         }
     }
 
@@ -108,9 +113,12 @@ void Impl::ParseResponse( Response * response )
                 "response.new_device_revision",
                 &optarg) )
         {
-            response->new_device_revision = optarg;
+            response_data_ptr->new_device_revision = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/set_avatar/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/set_avatar/v1_3.hpp
@@ -35,10 +35,12 @@ enum class Action
 };
 
 /**
- * @class Response
- * @brief Response from API request "user/set_avatar"
+ * @class ResponseData
+ * @brief Response data from API request "user/set_avatar"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** The quickkey of the avatar. */
@@ -46,6 +48,17 @@ public:
 
     /** The revision of the cloud device if changed. */
     boost::optional<uint64_t> new_device_revision;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "user/set_avatar"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -95,7 +108,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/set_settings/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/set_settings/v1_3.cpp
@@ -99,6 +99,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/set_settings/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/set_settings/v1_3.hpp
@@ -45,12 +45,25 @@ enum class CollectMetadata
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/set_settings"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/set_settings"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -99,7 +112,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/unlink_facebook/v0.cpp
+++ b/src/mediafire_sdk/api/user/unlink_facebook/v0.cpp
@@ -75,6 +75,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/unlink_facebook/v0.hpp
+++ b/src/mediafire_sdk/api/user/unlink_facebook/v0.hpp
@@ -27,12 +27,25 @@ namespace unlink_facebook {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/unlink_facebook"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/unlink_facebook"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -52,7 +65,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/unlink_facebook/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/unlink_facebook/v1_3.cpp
@@ -75,6 +75,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/unlink_facebook/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/unlink_facebook/v1_3.hpp
@@ -27,12 +27,25 @@ namespace unlink_facebook {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/unlink_facebook"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/unlink_facebook"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -52,7 +65,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/unlink_twitter/v0.cpp
+++ b/src/mediafire_sdk/api/user/unlink_twitter/v0.cpp
@@ -75,6 +75,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/unlink_twitter/v0.hpp
+++ b/src/mediafire_sdk/api/user/unlink_twitter/v0.hpp
@@ -27,12 +27,25 @@ namespace unlink_twitter {
 namespace v0 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/unlink_twitter"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/unlink_twitter"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -52,7 +65,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/unlink_twitter/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/unlink_twitter/v1_3.cpp
@@ -75,6 +75,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/unlink_twitter/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/unlink_twitter/v1_3.hpp
@@ -27,12 +27,25 @@ namespace unlink_twitter {
 namespace v1_3 {
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/unlink_twitter"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/unlink_twitter"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -52,7 +65,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/update/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/update/v1_3.cpp
@@ -123,6 +123,7 @@ void Impl::ParseResponse( Response * /* response */ )
     }
 
 
+
 #   undef return_error
 }
 

--- a/src/mediafire_sdk/api/user/update/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/update/v1_3.hpp
@@ -57,12 +57,25 @@ enum class PrimaryUsage
 };
 
 /**
+ * @class ResponseData
+ * @brief Response data from API request "user/update"
+ *
+ * This data is only available if the API request was successful.
+ */
+class ResponseData
+{
+public:
+};
+
+/**
  * @class Response
  * @brief Response from API request "user/update"
  */
 class Response : public ResponseBase
 {
 public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -200,7 +213,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/user_register/v0.cpp
+++ b/src/mediafire_sdk/api/user/user_register/v0.cpp
@@ -86,11 +86,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.email",
-            &response->email ) )
+            &response_data_ptr->email ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.email\"");
@@ -99,7 +104,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.created",
-            &response->created_datetime ) )
+            &response_data_ptr->created_datetime ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.created\"");
@@ -108,7 +113,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.pkey",
-            &response->pkey ) )
+            &response_data_ptr->pkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.pkey\"");
@@ -121,9 +126,12 @@ void Impl::ParseResponse( Response * response )
                 "response.temp_pw",
                 &optarg) )
         {
-            response->temporary_password = optarg;
+            response_data_ptr->temporary_password = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/user_register/v0.hpp
+++ b/src/mediafire_sdk/api/user/user_register/v0.hpp
@@ -27,10 +27,12 @@ namespace user_register {
 namespace v0 {
 
 /**
- * @class Response
- * @brief Response from API request "user/register"
+ * @class ResponseData
+ * @brief Response data from API request "user/register"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** Email associated with the account */
@@ -45,6 +47,17 @@ public:
 
     /** Temporary password assigned when no password was provided. */
     boost::optional<std::string> temporary_password;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "user/register"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -110,7 +123,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/api/user/user_register/v1_3.cpp
+++ b/src/mediafire_sdk/api/user/user_register/v1_3.cpp
@@ -86,11 +86,16 @@ void Impl::ParseResponse( Response * response )
         return;                                                                \
     }
 
+    ResponseData response_data;
+
+    // For uniformity for code generation with the other content parsers.
+    ResponseData * response_data_ptr = &response_data;
+
     // create_content_parse_single required
     if ( ! GetIfExists(
             response->pt,
             "response.email",
-            &response->email ) )
+            &response_data_ptr->email ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.email\"");
@@ -99,7 +104,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.created",
-            &response->created_datetime ) )
+            &response_data_ptr->created_datetime ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.created\"");
@@ -108,7 +113,7 @@ void Impl::ParseResponse( Response * response )
     if ( ! GetIfExists(
             response->pt,
             "response.pkey",
-            &response->pkey ) )
+            &response_data_ptr->pkey ) )
         return_error(
             mf::api::api_code::ContentInvalidData,
             "missing \"response.pkey\"");
@@ -121,9 +126,12 @@ void Impl::ParseResponse( Response * response )
                 "response.temp_pw",
                 &optarg) )
         {
-            response->temporary_password = optarg;
+            response_data_ptr->temporary_password = optarg;
         }
     }
+
+    // Only on success, return parsed data structure with response
+    response->response_data = std::move(response_data); 
 
 #   undef return_error
 }

--- a/src/mediafire_sdk/api/user/user_register/v1_3.hpp
+++ b/src/mediafire_sdk/api/user/user_register/v1_3.hpp
@@ -27,10 +27,12 @@ namespace user_register {
 namespace v1_3 {
 
 /**
- * @class Response
- * @brief Response from API request "user/register"
+ * @class ResponseData
+ * @brief Response data from API request "user/register"
+ *
+ * This data is only available if the API request was successful.
  */
-class Response : public ResponseBase
+class ResponseData
 {
 public:
     /** Email associated with the account */
@@ -45,6 +47,17 @@ public:
 
     /** Temporary password assigned when no password was provided. */
     boost::optional<std::string> temporary_password;
+};
+
+/**
+ * @class Response
+ * @brief Response from API request "user/register"
+ */
+class Response : public ResponseBase
+{
+public:
+    /** Parsed API response on successful parse. */
+    boost::optional<ResponseData> response_data;
 };
 
 class Impl;
@@ -110,7 +123,10 @@ public:
     // Remaining functions are for use by API library only. --------------------
 
     /** Requester/SessionMaintainer expected type. */
-    typedef Response ResponseType;
+    using ResponseType = Response;
+
+    /** Requester/SessionMaintainer expected type. */
+    using ResponseDataType = ResponseData;
 
     /** Requester/SessionMaintainer expected type. */
     typedef std::function< void( const ResponseType & data)> CallbackType;

--- a/src/mediafire_sdk/uploader/detail/transition_check.hpp
+++ b/src/mediafire_sdk/uploader/detail/transition_check.hpp
@@ -18,86 +18,90 @@
 #include "mediafire_sdk/uploader/detail/upload_target.hpp"
 #include "mediafire_sdk/utils/string.hpp"
 
-namespace mf {
-namespace uploader {
-namespace detail {
-namespace upload_transition {
-
-template<typename FSM>
-void HandleCheck(
-        FSM & fsm,
-        const mf::api::upload::check::Response & response
-    )
+namespace mf
 {
-    assert( ! fsm.filename().empty());
+namespace uploader
+{
+namespace detail
+{
+namespace upload_transition
+{
+
+template <typename FSM>
+void HandleCheck(FSM & fsm, const mf::api::upload::check::Response & response)
+{
+    assert(!fsm.filename().empty());
+
+    // This function should never receive a bad response.
+    assert(response.response_data);
+
+    const auto & response_data = *response.response_data;
 
     namespace chk = mf::api::upload::check;
 
-    if (response.file_exists == chk::FilenameInFolder::Yes
-        && response.hash_different == chk::FileExistsWithDifferentHash::No
-        && response.duplicate_quickkey
-        )
+    if (response_data.file_exists == chk::FilenameInFolder::Yes
+        && response_data.hash_different == chk::FileExistsWithDifferentHash::No
+        && response_data.duplicate_quickkey)
     {
         // Filename same and hash same.  We are already done here.
-        fsm.ProcessEvent( event::AlreadyUploaded{ *response.duplicate_quickkey,
-            fsm.filename() });
+        fsm.ProcessEvent(event::AlreadyUploaded{
+                *response_data.duplicate_quickkey, fsm.filename()});
     }
-    else if (response.storage_limit_exceeded == chk::StorageLimitExceeded::Yes)
+    else if (response_data.storage_limit_exceeded
+             == chk::StorageLimitExceeded::Yes)
     {
         // Can't upload, insufficient space.
 
-        fsm.ProcessEvent( event::Error{
+        fsm.ProcessEvent(event::Error{
                 make_error_code(mf::uploader::errc::InsufficientCloudStorage),
-                "Account lacks sufficient storage for upload to cloud"
-            } );
+                "Account lacks sufficient storage for upload to cloud"});
     }
-    else if (response.file_exists == chk::FilenameInFolder::Yes
-        &&  fsm.onDuplicateAction() != OnDuplicateAction::Replace
-        && fsm.onDuplicateAction() != OnDuplicateAction::AutoRename )
+    else if (response_data.file_exists == chk::FilenameInFolder::Yes
+             && fsm.onDuplicateAction() != OnDuplicateAction::Replace
+             && fsm.onDuplicateAction() != OnDuplicateAction::AutoRename)
     {
         switch (fsm.onDuplicateAction())
         {
             case OnDuplicateAction::Fail:
-                fsm.ProcessEvent( event::Error{
-                    make_error_code(mf::uploader::errc::FileExistInFolder),
-                    "File already exists in folder."
-                    } );
+                fsm.ProcessEvent(event::Error{
+                        make_error_code(mf::uploader::errc::FileExistInFolder),
+                        "File already exists in folder."});
                 break;
             default:
                 assert(!"Unhandled duplicate action");
         }
     }
-    else if (response.hash_exists == chk::HashAlreadyInSystem::Yes)
+    else if (response_data.hash_exists == chk::HashAlreadyInSystem::Yes)
     {
-        fsm.ProcessEvent( event::InstantUpload{} );
+        fsm.ProcessEvent(event::InstantUpload{});
     }
     else if (fsm.chunkRanges().size() > 1)
     {
-        if ( ! response.resumable )
+        if (!response_data.resumable)
         {
             assert(!"bitmap missing when it should exist");
-            fsm.ProcessEvent( event::NeedsSingleUpload{} );
+            fsm.ProcessEvent(event::NeedsSingleUpload{});
         }
         else
         {
-            const auto & resumable = *response.resumable;
+            const auto & resumable = *response_data.resumable;
             if (resumable.number_of_units != fsm.chunkRanges().size())
             {
                 assert(!"unit count does not match chunk count");
-                fsm.ProcessEvent( event::NeedsSingleUpload{} );
+                fsm.ProcessEvent(event::NeedsSingleUpload{});
             }
             else
             {
                 fsm.SetBitmap(resumable.words);
 
                 // Do upload
-                fsm.ProcessEvent( event::NeedsChunkUpload{} );
+                fsm.ProcessEvent(event::NeedsChunkUpload{});
             }
         }
     }
     else
     {
-        fsm.ProcessEvent( event::NeedsSingleUpload{} );
+        fsm.ProcessEvent(event::NeedsSingleUpload{});
     }
 }
 
@@ -106,10 +110,10 @@ struct Check
     class TargetSetter : public boost::static_visitor<>
     {
     public:
-        TargetSetter(
-                ::mf::api::upload::check::Request * request
-            ) :
-            request_(request) {}
+        TargetSetter(::mf::api::upload::check::Request * request)
+                : request_(request)
+        {
+        }
 
         void operator()(ParentFolderKey variant) const
         {
@@ -125,13 +129,11 @@ struct Check
         ::mf::api::upload::check::Request * request_;
     };
 
-    template <typename Event, typename FSM, typename SourceState, typename TargetState>
-    void operator()(
-            Event const &,
-            FSM & fsm,
-            SourceState&,
-            TargetState&
-        )
+    template <typename Event,
+              typename FSM,
+              typename SourceState,
+              typename TargetState>
+    void operator()(Event const &, FSM & fsm, SourceState &, TargetState &)
     {
         auto request = ::mf::api::upload::check::Request(fsm.filename());
         request.SetHash(fsm.hash());
@@ -144,36 +146,34 @@ struct Check
         if (fsm.chunkRanges().size() > 1)
         {
             // If multiple chunks, we should set resumable
-            request.SetResumable(::mf::api::upload::check::Resumable::Resumable);
+            request.SetResumable(
+                    ::mf::api::upload::check::Resumable::Resumable);
         }
 
         auto fsmp = fsm.AsFrontShared();
 
         fsm.GetSessionMaintainer()->Call(
-            request,
-            [fsmp](const mf::api::upload::check::Response & response)
-            {
-                if (response.error_code)
+                request,
+                [fsmp](const mf::api::upload::check::Response & response)
                 {
-                    std::string error_str = "unknown error";
-                    if (response.error_string)
-                        error_str = *response.error_string;
+                    if (!response.response_data)
+                    {
+                        assert(response.error_code);
 
-                    fsmp->ProcessEvent(
-                        event::Error{
-                            response.error_code,
-                            error_str
-                        });
-                }
-                else
-                {
-                    HandleCheck(*fsmp, response);
-                }
-            }
-        );
+                        std::string error_str = "unknown error";
+                        if (response.error_string)
+                            error_str = *response.error_string;
+
+                        fsmp->ProcessEvent(
+                                event::Error{response.error_code, error_str});
+                    }
+                    else
+                    {
+                        HandleCheck(*fsmp, response);
+                    }
+                });
     }
 };
-
 
 }  // namespace upload_transition
 }  // namespace detail

--- a/src/mediafire_sdk/utils/string.cpp
+++ b/src/mediafire_sdk/utils/string.cpp
@@ -11,9 +11,9 @@
 #       include <windows.h>
 #       include <vector>
 #else
-#       include <codecvt>
 #       include <locale>
 #       include <string>
+#       include "boost/locale/encoding_utf.hpp"
 #endif
 
 #if defined(__MINGW32__)
@@ -125,6 +125,9 @@ std::wstring mf::utils::bytes_to_wide(const std::string & byte_string)
     return buffer;
 }
 #else
+
+using boost::locale::conv::utf_to_utf;
+
 uint64_t mf::utils::str_to_uint64(
         const std::string & str,
         int base
@@ -134,14 +137,12 @@ uint64_t mf::utils::str_to_uint64(
 }
 std::string mf::utils::wide_to_bytes(const std::wstring & str)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.to_bytes(str);
+    return utf_to_utf<char>(str.c_str(), str.c_str() + str.size());
 }
 
 std::wstring mf::utils::bytes_to_wide(const std::string & str)
 {
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.from_bytes(str);
+    return utf_to_utf<wchar_t>(str.c_str(), str.c_str() + str.size());
 }
 #endif
 


### PR DESCRIPTION
There were cases of accidental misuse of API fields that are only available when the API response was successful.  This is undefined behavior and preventing it can be ensured at compile time.

This adds the field ```response_data``` to all API ```Response```s.  This field is only populated when the API request was successful.