### PR TITLE
ENH prefer content length over short read error

### DIFF
--- a/src/mediafire_sdk/http/detail/state_read_content.hpp
+++ b/src/mediafire_sdk/http/detail/state_read_content.hpp
@@ -314,6 +314,8 @@ void HandleContentRead(
     // Fail if content length incorrect on read complete
     if (exceeded_full_content)
     {
+        // We have read more data than we requested, and more than the server
+        // told us to expect.
         std::stringstream ss;
         ss << "Failure while reading content.";
         ss << " Url: " << fsm.get_url();
@@ -329,6 +331,8 @@ void HandleContentRead(
     else if (connection_terminated && using_content_length
              && !reached_full_content)
     {
+        // The connection was terminated and we know we haven't read enough
+        // data yet.
         std::stringstream ss;
         ss << "Early termination of content read.";
         ss << " Url: " << fsm.get_url();


### PR DESCRIPTION
If SSL returns a "short read" when it has the content length and the
response is obviously complete due to having received all the content
based on the content length, then there is no error.

Also, try to read a header with "short read" when there is content
returned to read.  Possibly the header contains a redirect or error
information.