### PR TITLE
Revert "BUG Handle relative HTTP redirects"

### DIFF
--- a/src/mediafire_sdk/http/detail/state_parse_headers.hpp
+++ b/src/mediafire_sdk/http/detail/state_parse_headers.hpp
@@ -46,8 +46,7 @@ public:
             {
                 try {
                     auto iface = fsm.get_callback();
-                    auto url = mf::http::Url(
-                        fsm.get_parsed_url()->FromRedirect(it->second));
+                    auto url = mf::http::Url(it->second);
 
                     mf::http::Headers headers = { evt.raw_headers,
                         evt.status_code, evt.status_message, evt.headers };
@@ -69,7 +68,7 @@ public:
                     }
 
                     RedirectEvent redirect(evt);
-                    redirect.redirect_url = url.full_path();
+                    redirect.redirect_url = it->second;
                     fsm.ProcessEvent(redirect);
                 }
                 catch(mf::http::InvalidUrl & err)


### PR DESCRIPTION
Reverts MediaFire/mediafire-cpp-sdk#19 as it breaks the test `TestHttpRedirectPermission`.