### PR TITLE
ENH define mpl vector size for faster compilation

### DIFF
--- a/src/mediafire_sdk/http/CMakeLists.txt
+++ b/src/mediafire_sdk/http/CMakeLists.txt
@@ -54,7 +54,6 @@ endforeach()
 
 add_definitions(
     -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-    -DBOOST_MPL_LIMIT_VECTOR_SIZE=40 # Set max MSM transitions
     -DBOOST_MPL_LIMIT_MAP_SIZE=40 # Set max MSM transitions
     -DFUSION_MAX_VECTOR_SIZE=20 # Set max MSM states
     )
@@ -78,4 +77,3 @@ TARGET_LINK_LIBRARIES(mf_http_sdk
 
 add_subdirectory(standalone)
 add_subdirectory(unit_tests)
-

--- a/src/mediafire_sdk/http/detail/http_request_state_machine.hpp
+++ b/src/mediafire_sdk/http/detail/http_request_state_machine.hpp
@@ -14,6 +14,8 @@
 #include <utility>
 #include <iostream>
 
+#include "boost/mpl/vector/vector40.hpp"
+
 #include "boost/msm/back/state_machine.hpp"
 #include "boost/msm/front/state_machine_def.hpp"
 #include "boost/msm/front/euml/operator.hpp"
@@ -480,7 +482,7 @@ public:
     typedef HttpRequestMachine_ m;  // makes transition table cleaner
 
     // Transition table for HttpRequestMachine
-    struct transition_table : mpl::vector<
+    struct transition_table : mpl::vector31<
         //    Start           Event                   Next            Action                Guard                                  // NOLINT
         //  +---------------+-----------------------+---------------+---------------------+------------------------------------+   // NOLINT
         Row < Unstarted     , ConfigEvent           , Unstarted     , ConfigEventAction   , none                               >,  // NOLINT

--- a/src/mediafire_sdk/uploader/CMakeLists.txt
+++ b/src/mediafire_sdk/uploader/CMakeLists.txt
@@ -50,7 +50,6 @@ endforeach()
 
 add_definitions(
     -DBOOST_MPL_CFG_NO_PREPROCESSED_HEADERS
-    -DBOOST_MPL_LIMIT_VECTOR_SIZE=40 # Set max MSM transitions
     -DBOOST_MPL_LIMIT_MAP_SIZE=40 # Set max MSM transitions
     -DFUSION_MAX_VECTOR_SIZE=20 # Set max MSM states
 )

--- a/src/mediafire_sdk/uploader/detail/upload_state_machine.hpp
+++ b/src/mediafire_sdk/uploader/detail/upload_state_machine.hpp
@@ -14,6 +14,7 @@
 
 #include "mediafire_sdk/http/bandwidth_analyser_interface.hpp"
 
+#include "boost/mpl/vector/vector30.hpp"
 #include "boost/msm/back/state_machine.hpp"
 #include "boost/msm/front/state_machine_def.hpp"
 #include "boost/msm/front/euml/operator.hpp"
@@ -486,7 +487,7 @@ public:
     typedef Initial initial_state;
 
     // Transition table for StateMachine
-    struct transition_table : mpl::vector<
+    struct transition_table : mpl::vector25<
         //    Start               , Event                       , Next                , Action              , Guard
         // ---------------------- , --------------------------- , ------------------- , ------------------  , ------------------
         Row < Initial             , event::Start                , WaitForHashSignal   , none                , Not_<HasHash>      >,

--- a/src/mediafire_sdk/uploader/hasher.cpp
+++ b/src/mediafire_sdk/uploader/hasher.cpp
@@ -14,6 +14,7 @@
 #include "boost/msm/back/state_machine.hpp"
 #include "boost/msm/front/state_machine_def.hpp"
 #include <boost/msm/front/functor_row.hpp>
+#include "boost/mpl/vector/vector10.hpp"
 
 #include "mediafire_sdk/utils/error.hpp"
 #include "mediafire_sdk/utils/fileio.hpp"
@@ -84,7 +85,7 @@ public:
     typedef Unstarted initial_state;
 
     // Transition table for Hasher_
-    struct transition_table : mpl::vector<
+    struct transition_table : mpl::vector6<
         //    Start     , Event           , Next    , Action        , Guard
         // ------------ , --------------- , ------- , ------------- , -----
         Row < Unstarted , he::StartHash   , Started , ht::OpenFile  , none  >,


### PR DESCRIPTION
For mpl vectors over length of 10 it is recommend to define the exact vector size for each vector as not defining it affects compilation time negatively.

This removes the BOOST_MPL_LIMIT_VECTOR_SIZE define which can slow down compilation excessively.