### PR TITLE
BUG Delete folders with trash parent

### DIFF
--- a/src/mediafire_sdk/api/actions/get_foreign_changes_device_impl.hpp
+++ b/src/mediafire_sdk/api/actions/get_foreign_changes_device_impl.hpp
@@ -96,8 +96,15 @@ void GetForeignChangesDevice<TDeviceGetForeignChangesRequest>::CoroutineBody(
                 // HACK around the API including "trash" inside
                 // updated_folders
                 for (const auto & folder : data.updated_folders)
-                    if (folder.folderkey != "trash")
+                {
+                    bool is_trash = folder.folderkey == "trash";
+                    bool is_in_trash = folder.parent_folderkey &&
+                        *folder.parent_folderkey == "trash";
+                    if (!is_trash && !is_in_trash)
                         updated_folders_.push_back(folder);
+                    if (is_in_trash)
+                        deleted_folders_.push_back(folder);
+                }
 
                 deleted_files_.insert(std::end(deleted_files_),
                                       std::begin(data.deleted_files),

--- a/src/mediafire_sdk/api/actions/poll_changes_impl.hpp
+++ b/src/mediafire_sdk/api/actions/poll_changes_impl.hpp
@@ -66,16 +66,23 @@ void PollChanges<TDeviceGetStatusRequest,
     get_changes_errors_ = get_changes_errors;
 
     updated_files_ = updated_files;
+    deleted_files_ = deleted_files;
+    deleted_folders_ = deleted_folders;
 
     // updated_folders_ = updated_folders;
     // Hack around updated_folders containing trash folder key
+    // Also hack around deleted folders showing up in updates
     // -_-
     for (const auto & updated_folder : updated_folders)
-        if (updated_folder.folderkey != "trash")
+    {
+        bool is_trash = updated_folder.folderkey == "trash";
+        bool is_in_trash = updated_folder.parent_folderkey &&
+                *updated_folder.parent_folderkey == "trash";
+        if (!is_trash && !is_in_trash)
             updated_folders_.push_back(updated_folder);
-
-    deleted_files_ = deleted_files;
-    deleted_folders_ = deleted_folders;
+        if (is_in_trash)
+            deleted_folders_.push_back(updated_folder);
+    }
 
     Resume();
 }


### PR DESCRIPTION
Folders are sometimes returned by the API with the 'trash' parent, but no
  deleted_date set, and in the 'updated' list instead of 'deleted', so we
  work around this.